### PR TITLE
Add mouse profiles

### DIFF
--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -29,6 +29,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // user without it is always walked through it rather than left with a silently-dead app.
         // Button remapping additionally needs Accessibility (optional; surfaced in the same window).
         permissions.recheck()
+        // A manual button-remap edit (outside applying a profile) means the live config no
+        // longer matches whichever profile was last applied — let MouseController know so it
+        // can drop the stale "active" highlight.
+        remapper.onManualChange = { [weak controller] in controller?.clearActiveProfileIfManuallyChanged() }
         if !permissions.inputMonitoring {
             DispatchQueue.main.async { [weak self] in self?.permissionsWindow.show() }
         }

--- a/Sources/MacRazer/ButtonRemapper.swift
+++ b/Sources/MacRazer/ButtonRemapper.swift
@@ -124,9 +124,22 @@ final class ButtonRemapper: ObservableObject, @unchecked Sendable {
         (0, "Volume Up"), (1, "Volume Down"), (7, "Mute"),
     ]
 
+    /// Called after an individual button's mapping changes — lets owners (e.g. profile tracking
+    /// in `MouseController`) know the live config has drifted from whatever profile was applied.
+    var onManualChange: (() -> Void)?
+
     func setAction(_ action: RemapAction, for button: Int) {
         mappings[button] = action
         seenButtons.insert(button)
+        saveMappings()
+        onManualChange?()
+    }
+
+    /// Replaces the whole mapping table at once — used when applying a saved profile (as opposed
+    /// to a single-button edit from the remap UI, which goes through `setAction`).
+    func setMappings(_ new: [Int: RemapAction]) {
+        mappings = new
+        seenButtons.formUnion(new.keys)
         saveMappings()
     }
 

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -48,6 +48,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     @Published private(set) var bluetoothMouseName: String?
     private var ioHasBattery = true // io-queue mirror of deviceHasBattery
 
+    /// Saved DPI/poll/lighting/button-remap presets for the connected mouse, and which one (if
+    /// any) currently matches the live config. Loaded/swapped alongside `deviceKey` in
+    /// `ensureDevice()`, same as the battery history.
+    @Published private(set) var profiles: [MouseProfile] = []
+    @Published private(set) var activeProfileID: UUID?
+
     /// User preference: show the battery % beside the menu bar icon (persisted).
     @Published var showPercentInMenuBar: Bool = (UserDefaults.standard.object(forKey: "showPercentInMenuBar") as? Bool) ?? true {
         didSet {
@@ -349,7 +355,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         io.async { [weak self] in
             guard let self else { return }
             _ = try? self.ensureDevice().sendWithRetry(RazerCommands.setDPI(x: v, y: v))
-            self.publish { self.dpi = Int(v) }
+            self.publish { self.dpi = Int(v); self.clearActiveProfileIfNeeded() }
         }
     }
 
@@ -357,7 +363,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         io.async { [weak self] in
             guard let self else { return }
             _ = try? self.ensureDevice().sendWithRetry(RazerCommands.setPollingRate(hz))
-            self.publish { self.pollRate = hz }
+            self.publish { self.pollRate = hz; self.clearActiveProfileIfNeeded() }
         }
     }
 
@@ -366,7 +372,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         io.async { [weak self] in
             guard let self else { return }
             _ = try? self.ensureDevice().sendWithRetry(RazerCommands.setBrightness(RazerCommands.brightnessRaw(fromPercent: pct)))
-            self.publish { self.brightness = pct }
+            self.publish { self.brightness = pct; self.clearActiveProfileIfNeeded() }
         }
     }
 
@@ -377,7 +383,80 @@ final class MouseController: ObservableObject, @unchecked Sendable {
 
     private func send(_ report: RazerReport) {
         io.async { [weak self] in
-            _ = try? self?.ensureDevice().sendWithRetry(report)
+            guard let self else { return }
+            _ = try? self.ensureDevice().sendWithRetry(report)
+            self.publish { self.clearActiveProfileIfNeeded() }
+        }
+    }
+
+    // MARK: - Profiles
+
+    /// Suppressed while `applyProfile` is driving these same setters, so applying a profile
+    /// doesn't immediately un-mark itself as active.
+    private var isApplyingProfile = false
+
+    private func clearActiveProfileIfNeeded() {
+        guard !isApplyingProfile, activeProfileID != nil else { return }
+        activeProfileID = nil
+        if let key = deviceKey { ProfileStore.setActiveProfileID(nil, forDevice: key) }
+    }
+
+    /// Called by `ButtonRemapper.onManualChange` — a remap edit made outside `applyProfile`
+    /// means the live config no longer matches the active profile.
+    func clearActiveProfileIfManuallyChanged() { clearActiveProfileIfNeeded() }
+
+    /// Captures the current live DPI/poll/brightness/lighting + the remapper's button mappings
+    /// as a new named profile for the connected mouse.
+    func saveCurrentAsProfile(name: String, effect: String, color: RGB, remapper: ButtonRemapper) {
+        guard let key = deviceKey else { return }
+        let profile = MouseProfile(name: name, dpi: dpi, pollRate: pollRate == 0 ? 1000 : pollRate,
+                                    brightness: brightness, effect: effect, color: color,
+                                    buttonMappings: remapper.mappings)
+        profiles.append(profile)
+        ProfileStore.save(profiles, forDevice: key)
+        activeProfileID = profile.id
+        ProfileStore.setActiveProfileID(profile.id, forDevice: key)
+    }
+
+    /// Applies a saved profile's DPI/poll/brightness/lighting and button remaps to the live mouse.
+    func applyProfile(_ profile: MouseProfile, remapper: ButtonRemapper) {
+        guard let key = deviceKey else { return }
+        isApplyingProfile = true
+        setDPI(profile.dpi)
+        setPollRate(profile.pollRate)
+        setBrightness(profile.brightness)
+        switch profile.effect {
+        case "Static": setStatic(profile.color)
+        case "Spectrum": setSpectrum()
+        case "Wave": setWave()
+        default: setLightingOff()
+        }
+        remapper.setMappings(profile.buttonMappings)
+        // The writes above are dispatched async on `io`; flip the suppression flag back off
+        // once they've had a chance to land, then set the real active id.
+        io.async { [weak self] in
+            guard let self else { return }
+            self.publish {
+                self.isApplyingProfile = false
+                self.activeProfileID = profile.id
+                ProfileStore.setActiveProfileID(profile.id, forDevice: key)
+            }
+        }
+    }
+
+    func renameProfile(_ id: UUID, to newName: String) {
+        guard let key = deviceKey, let idx = profiles.firstIndex(where: { $0.id == id }) else { return }
+        profiles[idx].name = newName
+        ProfileStore.save(profiles, forDevice: key)
+    }
+
+    func deleteProfile(_ id: UUID) {
+        guard let key = deviceKey else { return }
+        profiles.removeAll { $0.id == id }
+        ProfileStore.save(profiles, forDevice: key)
+        if activeProfileID == id {
+            activeProfileID = nil
+            ProfileStore.setActiveProfileID(nil, forDevice: key)
         }
     }
 
@@ -405,6 +484,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         }
         averageCycleHours = 23
         updateStatusText()
+        let p1 = MouseProfile(name: "Work", dpi: 1600, pollRate: 1000, brightness: 60,
+                               effect: "Static", color: RGB(r: 0x44, g: 0xD6, b: 0x2C), buttonMappings: [:])
+        let p2 = MouseProfile(name: "Gaming", dpi: 6400, pollRate: 1000, brightness: 100,
+                               effect: "Spectrum", color: RGB(r: 255, g: 0, b: 0), buttonMappings: [:])
+        profiles = [p1, p2]
+        activeProfileID = p1.id
     }
 
     /// For the `render-ui offline` preview: keep last-known values but mark disconnected.
@@ -454,6 +539,8 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             let cycleStartPct = history.cycleStartedPercent
             let cycles = cycleHistory.cycles
             let avg = cycleHistory.averageCycleDuration.map { $0 / 3600 }
+            let loadedProfiles = ProfileStore.profiles(forDevice: key)
+            let loadedActiveID = ProfileStore.activeProfileID(forDevice: key)
             publish {
                 self.batterySamples = samples
                 self.dischargeRatePerHour = rate
@@ -461,6 +548,8 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 self.cycleStartedPercent = cycleStartPct
                 self.pastCycles = cycles
                 self.averageCycleHours = avg
+                self.profiles = loadedProfiles
+                self.activeProfileID = loadedActiveID
             }
         }
         let name = d.productName

--- a/Sources/MacRazer/MouseProfile.swift
+++ b/Sources/MacRazer/MouseProfile.swift
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// A named, switchable snapshot of everything the popover lets you configure: DPI, polling rate,
+/// lighting, and button remaps. The physical "profile" button on the mouse only cycles DPI
+/// stages in firmware — there's no onboard multi-profile storage or button-press notification to
+/// hook into, so switching profiles is an app-side action taken from the popover.
+struct MouseProfile: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var dpi: Int
+    var pollRate: Int
+    var brightness: Int // percent
+    /// Raw value of `PopoverView`'s `Effect` enum ("Static"/"Spectrum"/"Wave"/"Off").
+    var effect: String
+    /// Only meaningful when `effect == "Static"`.
+    var color: RGB
+    var buttonMappings: [Int: RemapAction]
+
+    init(name: String, dpi: Int, pollRate: Int, brightness: Int, effect: String, color: RGB,
+         buttonMappings: [Int: RemapAction]) {
+        self.id = UUID()
+        self.name = name
+        self.dpi = dpi
+        self.pollRate = pollRate
+        self.brightness = brightness
+        self.effect = effect
+        self.color = color
+        self.buttonMappings = buttonMappings
+    }
+
+    /// One-line summary shown under a profile's name in the manage page.
+    var summary: String {
+        "\(dpi) DPI · \(pollRate) Hz · \(effect)"
+    }
+}
+
+/// Per-device persistence for `[MouseProfile]`, following the same UserDefaults pattern as
+/// `ButtonRemapper`'s mapping storage (JSON-encoded `Data` under a device-keyed string).
+struct ProfileStore {
+    private static func key(forDevice deviceKey: String) -> String { "profiles-\(deviceKey)" }
+    private static func activeKey(forDevice deviceKey: String) -> String { "activeProfileID-\(deviceKey)" }
+
+    static func profiles(forDevice deviceKey: String) -> [MouseProfile] {
+        guard let data = UserDefaults.standard.data(forKey: key(forDevice: deviceKey)),
+              let decoded = try? JSONDecoder().decode([MouseProfile].self, from: data) else { return [] }
+        return decoded
+    }
+
+    static func save(_ profiles: [MouseProfile], forDevice deviceKey: String) {
+        guard let data = try? JSONEncoder().encode(profiles) else { return }
+        UserDefaults.standard.set(data, forKey: key(forDevice: deviceKey))
+    }
+
+    static func activeProfileID(forDevice deviceKey: String) -> UUID? {
+        guard let raw = UserDefaults.standard.string(forKey: activeKey(forDevice: deviceKey)) else { return nil }
+        return UUID(uuidString: raw)
+    }
+
+    static func setActiveProfileID(_ id: UUID?, forDevice deviceKey: String) {
+        if let id {
+            UserDefaults.standard.set(id.uuidString, forKey: activeKey(forDevice: deviceKey))
+        } else {
+            UserDefaults.standard.removeObject(forKey: activeKey(forDevice: deviceKey))
+        }
+    }
+}

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -34,8 +34,14 @@ struct PopoverView: View {
     @ObservedObject var remapper: ButtonRemapper
     @ObservedObject var updateChecker: UpdateChecker
 
-    enum Page { case main, color, buttons, usage }
+    enum Page { case main, color, buttons, usage, profiles }
     @State private var page: Page = .main
+    @State private var isAddingProfile = false
+    @State private var newProfileName = ""
+    /// Suppresses the `effect` picker's `onChange`-driven HID write while a profile apply is
+    /// updating `effect`/`color` to reflect the profile — `applyProfile` already sent the right
+    /// lighting command, and re-sending it here would also re-clear the just-set active profile.
+    @State private var isApplyingProfileLocally = false
 
     @State private var dpiValue: Double = 1600
     @State private var brightnessValue: Double = 100
@@ -74,6 +80,7 @@ struct PopoverView: View {
             case .color: colorPage.transition(.move(edge: .trailing))
             case .buttons: buttonsPage.transition(.move(edge: .trailing))
             case .usage: usagePage.transition(.move(edge: .trailing))
+            case .profiles: profilesPage.transition(.move(edge: .trailing))
             }
         }
         .frame(width: popoverWidth)
@@ -109,6 +116,13 @@ struct PopoverView: View {
         }
     }
 
+    private var profilesPage: some View {
+        ScrollView {
+            ProfilesView(controller: controller, remapper: remapper, onBack: { page = .main })
+                .frame(maxWidth: .infinity)
+        }
+    }
+
     private var mainPage: some View {
         VStack(alignment: .leading, spacing: 10) {
             headerCard
@@ -116,6 +130,7 @@ struct PopoverView: View {
             // A Razer mouse on Bluetooth can't be controlled (no control protocol over BT) —
             // explain it instead of just showing "offline".
             if controller.bluetoothMouseName != nil && !controller.connected { bluetoothNotice }
+            profilesCard.disabled(!controller.connected).opacity(controller.connected ? 1 : 0.45)
             // Battery stays readable (last-known) but dims when offline; its refresh button
             // stays active so you can retry.
             if controller.deviceHasBattery {
@@ -243,6 +258,104 @@ struct PopoverView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.batteryMid.opacity(0.12), in: RoundedRectangle(cornerRadius: 13))
+    }
+
+    // MARK: Profiles
+
+    /// Quick-switch row: a chip per saved profile (filled green when active) plus a "+" chip to
+    /// save the current setup. Kept on the main page so switching never needs a page navigation —
+    /// only the rarely-needed rename/delete flow lives behind "Manage…".
+    private var profilesCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    sectionLabel("Profiles", "person.crop.square.on.square.angled")
+                    Spacer()
+                    if !controller.profiles.isEmpty {
+                        Button("Manage…") { page = .profiles }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(Color.razerGreen)
+                    }
+                }
+                if controller.profiles.isEmpty && !isAddingProfile {
+                    HStack(spacing: 8) {
+                        Text("Save your current setup as a profile")
+                            .font(.system(size: 11)).foregroundStyle(.secondary)
+                        Spacer()
+                        addProfileChip
+                    }
+                } else {
+                    HStack(spacing: 6) {
+                        ForEach(controller.profiles) { profileChip($0) }
+                        if !isAddingProfile { addProfileChip }
+                    }
+                }
+                if isAddingProfile { addProfileField }
+            }
+        }
+    }
+
+    private func profileChip(_ profile: MouseProfile) -> some View {
+        let active = profile.id == controller.activeProfileID
+        return Button {
+            isApplyingProfileLocally = true
+            withAnimation(.easeInOut(duration: 0.2)) {
+                controller.applyProfile(profile, remapper: remapper)
+                if let parsed = Effect(rawValue: profile.effect) { effect = parsed }
+                color = Color(red: Double(profile.color.r) / 255, green: Double(profile.color.g) / 255, blue: Double(profile.color.b) / 255)
+            }
+            DispatchQueue.main.async { isApplyingProfileLocally = false }
+        } label: {
+            Text(profile.name)
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 10.5, weight: active ? .semibold : .regular))
+        .foregroundStyle(active ? .white : .secondary)
+        .padding(.horizontal, 10)
+        .frame(height: 24)
+        .background(active ? Color.razerGreen : Color.primary.opacity(0.08), in: Capsule())
+        .lineLimit(1)
+    }
+
+    private var addProfileChip: some View {
+        Button {
+            newProfileName = "Profile \(controller.profiles.count + 1)"
+            isAddingProfile = true
+        } label: {
+            Image(systemName: "plus").font(.system(size: 10.5, weight: .semibold))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(Color.razerGreen)
+        .frame(width: 24, height: 24)
+        .background(Color.razerGreen.opacity(0.12), in: Circle())
+        .overlay(Circle().stroke(Color.razerGreen.opacity(0.55), lineWidth: 1))
+    }
+
+    private var addProfileField: some View {
+        HStack(spacing: 6) {
+            TextField("Profile name", text: $newProfileName, onCommit: saveNewProfile)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11.5))
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+            Button("Save", action: saveNewProfile)
+                .buttonStyle(.borderedProminent)
+                .tint(.razerGreen)
+                .controlSize(.small)
+                .disabled(newProfileName.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Cancel") { isAddingProfile = false }
+                .buttonStyle(.plain)
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
+    }
+
+    private func saveNewProfile() {
+        let name = newProfileName.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+        controller.saveCurrentAsProfile(name: name, effect: effect.rawValue, color: color.rgb, remapper: remapper)
+        isAddingProfile = false
     }
 
     // MARK: Update notice
@@ -545,7 +658,7 @@ struct PopoverView: View {
             .pickerStyle(.segmented)
             .controlSize(.small)
             .labelsHidden()
-            .onChange(of: effect) { _, new in apply(effect: new) }
+            .onChange(of: effect) { _, new in if !isApplyingProfileLocally { apply(effect: new) } }
 
             if effect == .staticColor {
                 HStack(spacing: 7) {

--- a/Sources/MacRazer/ProfilesView.swift
+++ b/Sources/MacRazer/ProfilesView.swift
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import SwiftUI
+
+/// Manage page for saved profiles: rename, set active, delete. Reached via "Manage…" on the
+/// main page's profiles card; quick-switching itself happens from that card directly, so this
+/// page is only needed once there's more than one profile to curate.
+struct ProfilesView: View {
+    @ObservedObject var controller: MouseController
+    @ObservedObject var remapper: ButtonRemapper
+    var onBack: (() -> Void)?
+
+    @State private var renamingID: UUID?
+    @State private var renameText: String = ""
+    @State private var pendingDeleteID: UUID?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if controller.profiles.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(controller.profiles) { profile in
+                        row(for: profile)
+                    }
+                }
+            }
+        }
+        .padding(18)
+        .frame(width: onBack == nil ? 440 : 320)
+        .confirmationDialog("Delete this profile?", isPresented: Binding(
+            get: { pendingDeleteID != nil },
+            set: { if !$0 { pendingDeleteID = nil } }
+        ), titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                if let id = pendingDeleteID { controller.deleteProfile(id) }
+                pendingDeleteID = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDeleteID = nil }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let onBack { BackButton(action: onBack) }
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Profiles").font(.system(size: 16, weight: .semibold))
+                Text("Saved DPI, lighting and button setups you can switch between.")
+                    .font(.system(size: 11)).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("No profiles yet").font(.system(size: 12, weight: .medium))
+            Text("Use the + button on the main page to save your current setup as a profile.")
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func row(for profile: MouseProfile) -> some View {
+        let active = profile.id == controller.activeProfileID
+        return HStack(spacing: 10) {
+            Button {
+                controller.applyProfile(profile, remapper: remapper)
+            } label: {
+                ZStack {
+                    Circle().fill(active ? Color.razerGreen : Color.primary.opacity(0.10))
+                    if active {
+                        Image(systemName: "checkmark").font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+                }
+                .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .help(active ? "Active" : "Apply this profile")
+
+            VStack(alignment: .leading, spacing: 1) {
+                if renamingID == profile.id {
+                    TextField("Name", text: $renameText, onCommit: {
+                        controller.renameProfile(profile.id, to: renameText)
+                        renamingID = nil
+                    })
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12.5, weight: .medium))
+                } else {
+                    Text(profile.name).font(.system(size: 12.5, weight: .medium)).lineLimit(1)
+                }
+                Text(profile.summary).font(.system(size: 10.5)).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+
+            Button {
+                renameText = profile.name
+                renamingID = profile.id
+            } label: {
+                Image(systemName: "pencil").font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+
+            Button {
+                pendingDeleteID = profile.id
+            } label: {
+                Image(systemName: "trash").font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.batteryLow)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(active ? 0.10 : 0.06), in: RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Sources/MacRazer/RazerCommands.swift
+++ b/Sources/MacRazer/RazerCommands.swift
@@ -33,7 +33,7 @@ enum Razer {
 }
 
 /// RGB triple.
-struct RGB {
+struct RGB: Codable, Equatable {
     var r: UInt8, g: UInt8, b: UInt8
 }
 

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -67,6 +67,8 @@ case "render-ui":
         ? AnyView(ColorPickerPage(color: .constant(.blue), onBack: {}, onApply: { _ in }))
         : args.contains("usage")
         ? AnyView(UsageGraphView(controller: controller, onBack: {}))
+        : args.contains("profiles")
+        ? AnyView(ProfilesView(controller: controller, remapper: ButtonRemapper(), onBack: {}))
         : AnyView(PopoverView(controller: controller, remapper: ButtonRemapper(), updateChecker: UpdateChecker()))
     let renderer = ImageRenderer(content: rootView.padding(1).background(Color(white: 0.13)))
     renderer.scale = 2


### PR DESCRIPTION
## Summary
- Save the current DPI, polling rate, brightness, lighting effect/color, and button remaps as a named profile, and switch between saved profiles with one tap from a new Profiles card in the popover.
- A "Manage…" sub-page lets you rename, re-apply, or delete saved profiles.
- The physical profile button on the Cobra only cycles DPI stages in firmware (no onboard multi-profile storage, no press notification we can hook into), so switching is app-side, triggered from the UI.

## Test plan
- [x] `swift build` succeeds
- [x] `swift run MacRazer render-ui` and `render-ui ... profiles` checked visually (chips, manage page)
- [ ] Manual pass with a real Cobra: create 2 profiles with different DPI/color/remaps, switch between them, confirm device state changes and persists across relaunch