### PR TITLE
Add learned discharge curve for the Cobra HyperSpeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/). The project is **pre-release** (0.x) —
 expect rough edges until 1.0.
 
+## [Unreleased]
+
+### Added
+- **Learned discharge curve for the Razer Cobra HyperSpeed.** Rather than one flat %/hour rate,
+ the app now learns how long the battery actually dwells at each percent (0-100) from real
+ discharge history, specifically for the Cobra HyperSpeed (wired + wireless) — its Li-ion cell
+ has a long flat voltage plateau through most of the discharge and steep drops near full/empty,
+ which a single linear rate can't represent. The learned curve is shared across every Cobra
+ HyperSpeed unit the app sees (not per physical mouse) so it improves faster, and falls back to
+ the existing linear-rate estimate for any percent it doesn't have data for yet — with zero
+ data the estimate is identical to before. Every other mouse model is unaffected and keeps
+ using the generic estimate, since their cell/firmware behavior is unverified.
+- **Usage graph now covers the whole charge, not just the last ~2 hours.** The retained sample
+ window was raised from 500 to 25,000 (~104 hours), and the discharge curve on the usage page
+ is now colored green/orange/red at the same thresholds as the main battery bar, instead of a
+ flat color.
+
+### Fixed
+- **A multi-hour disconnect or sleep gap no longer gets learned as real per-percent dwell
+ time.** The discharge-curve model could mistake "mouse was offline for hours" for "battery
+ sat at this percent for hours," skewing its estimate after as few as two such gaps; intervals
+ longer than 5 minutes are now excluded from what it learns from.
+
+### Changed
+- Persisting battery/discharge-curve history to disk is now throttled (~every 30s, plus
+ immediately on a charge-cycle boundary) instead of on every poll tick, now that the larger
+ sample window would otherwise mean rewriting a much bigger file every 4-15 seconds.
+
 ## [0.1.5] — 2026-06-29
 
 ### Added

--- a/Sources/MacRazer/BatteryHistory.swift
+++ b/Sources/MacRazer/BatteryHistory.swift
@@ -16,8 +16,11 @@ final class BatteryHistory {
     private let url: URL
     private(set) var samples: [BatterySample] = []
 
-    /// Keep a bounded window so a single charge cycle dominates the fit.
-    private let maxSamples = 500
+    /// Keep a bounded window so a single charge cycle dominates the fit, but generous enough
+    /// that the usage graph can show the *whole* cycle rather than just a recent slice — at the
+    /// 15s connected-poll interval this covers a bit over 100 hours (~4 days), comfortably past
+    /// any realistic single-charge duration for these mice.
+    private let maxSamples = 25_000
     /// Per-device key (e.g. the PID hex) so each mouse keeps its own history + learned rate.
     private let deviceKey: String
 
@@ -26,6 +29,22 @@ final class BatteryHistory {
     /// a near-empty array during a single charge session). Callers must filter noise themselves;
     /// `ChargeCycleHistory.recordFinishedCycle` does this via its span/drop thresholds.
     var onCycleFinished: (([BatterySample]) -> Void)?
+
+    /// Fired with (previous percent, new percent, elapsed seconds) for every consecutive
+    /// in-cycle sample pair — the raw signal `DischargeCurveModel` learns dwell times from.
+    var onInterval: ((_ fromPercent: Int, _ toPercent: Int, _ duration: TimeInterval) -> Void)?
+
+    /// Above this, a gap between two samples isn't real dwell time — the mouse went to sleep,
+    /// got disconnected, or the app was closed, none of which the device "remembers" as
+    /// discharging once reconnected. Generous margin above both poll cadences (4-15s) so it
+    /// never clips a real interval, but well short of any genuine offline gap. Without this, a
+    /// multi-hour disconnect gets credited to `DischargeCurveModel` as multi-hour dwell time at
+    /// whatever percent(s) it spans, corrupting that bucket's learned mean after as few as two
+    /// such gaps (no decay/down-weighting — it's a plain running average).
+    private let maxIntervalForDwellLearning: TimeInterval = 5 * 60
+
+    private var lastSaveAt = Date.distantPast
+    private let saveInterval: TimeInterval = 30
 
     init(deviceKey: String) {
         self.deviceKey = deviceKey
@@ -38,15 +57,29 @@ final class BatteryHistory {
     }
 
     func record(percent: Int, charging: Bool) {
+        let now = Date()
         // A charge event invalidates the discharge trend — reset the window on an uptick.
         let isReset = (samples.last.map { percent > $0.pct + 1 } ?? false) || charging
         if isReset {
             if !samples.isEmpty { onCycleFinished?(samples) }
             samples.removeAll()
+        } else if let last = samples.last {
+            let elapsed = now.timeIntervalSince(last.t)
+            if elapsed <= maxIntervalForDwellLearning {
+                onInterval?(last.pct, percent, elapsed)
+            }
         }
-        samples.append(BatterySample(t: Date(), pct: percent))
+        samples.append(BatterySample(t: now, pct: percent))
         if samples.count > maxSamples { samples.removeFirst(samples.count - maxSamples) }
-        save()
+        // Persisting on every tick made sense at the old 500-sample cap; at 25,000 it'd mean
+        // rewriting a much bigger file to disk every 4-15s. Always save promptly right after a
+        // reset (the array is small then, and it's a meaningful boundary worth not losing);
+        // otherwise throttle to a periodic save — losing a few seconds of the in-memory tail on
+        // an unclean quit is an acceptable trade for not hammering disk all cycle long.
+        if isReset || now.timeIntervalSince(lastSaveAt) >= saveInterval {
+            lastSaveAt = now
+            save()
+        }
     }
 
     /// Time the current discharge cycle started (the oldest sample since the last reset), or
@@ -71,18 +104,27 @@ final class BatteryHistory {
     }
 
     /// Hours remaining. Prefers a fresh per-session slope (and folds it into the learned rate);
-    /// otherwise falls back to the persisted learned rate.
-    func estimateHoursRemaining(currentPercent: Int) -> Double? {
-        if let rate = sessionRatePerHour() {
+    /// otherwise falls back to the persisted learned rate. If `curveModel` is given (only for
+    /// models with a learned per-percent discharge curve — see `DischargeCurveModel`) and it
+    /// can produce an estimate, that wins over the plain `currentPercent / rate` projection,
+    /// since a single rate can't represent a non-linear discharge curve. The rate is still
+    /// computed/persisted exactly as before either way — it's also the curve model's own
+    /// per-bucket fallback for percents it doesn't have data for yet.
+    func estimateHoursRemaining(currentPercent: Int, curveModel: DischargeCurveModel? = nil) -> Double? {
+        var rate: Double?
+        if let session = sessionRatePerHour() {
             // Blend the observed rate into the long-term learned rate (EMA), then use it.
-            let blended = learnedRatePerHour.map { 0.8 * $0 + 0.2 * rate } ?? rate
+            let blended = learnedRatePerHour.map { 0.8 * $0 + 0.2 * session } ?? session
             learnedRatePerHour = min(max(blended, 0.05), 60)
-            return Double(currentPercent) / rate
+            rate = session
+        } else if let learned = learnedRatePerHour, learned > 0 {
+            rate = learned
         }
-        if let rate = learnedRatePerHour, rate > 0 {
-            return Double(currentPercent) / rate
+        if let curveModel, let estimate = curveModel.estimateHoursRemaining(currentPercent: currentPercent, fallbackRatePerHour: rate) {
+            return estimate
         }
-        return nil
+        guard let rate else { return nil }
+        return Double(currentPercent) / rate
     }
 
     /// Linear least-squares fit of the current samples → discharge rate in %/hour (positive),
@@ -114,8 +156,8 @@ final class BatteryHistory {
     }
 
     /// Human-readable "~Xh Ym" / "~Xd Yh" string, or nil.
-    func estimateString(currentPercent: Int) -> String? {
-        guard let hours = estimateHoursRemaining(currentPercent: currentPercent) else { return nil }
+    func estimateString(currentPercent: Int, curveModel: DischargeCurveModel? = nil) -> String? {
+        guard let hours = estimateHoursRemaining(currentPercent: currentPercent, curveModel: curveModel) else { return nil }
         return "~\(Self.formatDuration(hours: hours)) left (est.)"
     }
 

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -18,3 +18,13 @@ func sectionLabel(_ text: String, _ symbol: String) -> some View {
         .font(.system(size: 11, weight: .medium))
         .foregroundStyle(.secondary)
 }
+
+/// Battery-state color for a given percent — the same low/mid/full thresholds as the battery
+/// card's level bar and gauge, shared so the usage graph's discharge curve matches it exactly.
+func batteryLevelColor(forPercent pct: Int) -> Color {
+    switch pct {
+    case ..<15: return .batteryLow
+    case ..<40: return .batteryMid
+    default: return .batteryFull
+    }
+}

--- a/Sources/MacRazer/DischargeCurveModel.swift
+++ b/Sources/MacRazer/DischargeCurveModel.swift
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// Running mean of how long the battery actually dwells at each percent (0-100), learned from
+/// real discharge history. A Li-ion cell's voltage — and so a firmware fuel gauge's reported
+/// percent — isn't linear with time: there's a long flat plateau through most of the
+/// discharge, then steep drops near full and near empty. A single %/hour rate (the generic
+/// model `BatteryHistory` uses for every other mouse) can't represent that shape; this can,
+/// because each percent gets its own learned dwell time instead of one shared rate.
+struct DischargeBucket: Codable {
+    var totalSeconds: Double = 0
+    var count: Int = 0
+    var mean: Double? { count > 0 ? totalSeconds / Double(count) : nil }
+}
+
+final class DischargeCurveModel {
+    private let url: URL
+    /// Index 0...100 = percent. 101 buckets, always fully allocated (some just empty).
+    private(set) var buckets: [DischargeBucket]
+    /// Below this many samples, a bucket falls back to the rate-derived estimate instead of
+    /// trusting its own (still-noisy) mean.
+    private let minSamplesToTrust = 2
+    /// `record()` fires on every poll tick while discharging — throttle the disk write rather
+    /// than re-encoding and rewriting all 101 buckets every 4-15s for what's typically a few
+    /// bytes of actual change. Losing a few seconds of the latest bucket update on an unclean
+    /// quit is an acceptable trade.
+    private var lastSaveAt = Date.distantPast
+    private let saveInterval: TimeInterval = 30
+
+    init(modelKey: String) {
+        let dir = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MacRazer", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        url = dir.appendingPathComponent("discharge-curve-\(modelKey).json")
+        buckets = Array(repeating: DischargeBucket(), count: 101)
+        load()
+    }
+
+    /// Distributes `duration` across every percent point crossed while discharging
+    /// (`fromPercent > toPercent`) — splitting evenly rather than crediting it all to
+    /// `fromPercent` matters near steep drops, where one poll interval can skip several
+    /// percent points at once. A flat interval credits its single bucket in full. A rising
+    /// interval (sensor noise — doesn't trigger `BatteryHistory`'s cycle reset) is ignored,
+    /// since there's no clean way to attribute it.
+    func record(fromPercent: Int, toPercent: Int, duration: TimeInterval) {
+        guard duration > 0, duration.isFinite else { return }
+        guard fromPercent >= toPercent, fromPercent >= 0, fromPercent <= 100, toPercent >= 0 else { return }
+        if fromPercent == toPercent {
+            add(duration, toBucket: fromPercent)
+        } else {
+            let span = fromPercent - toPercent
+            let share = duration / Double(span)
+            for pct in (toPercent + 1)...fromPercent { add(share, toBucket: pct) }
+        }
+        let now = Date()
+        guard now.timeIntervalSince(lastSaveAt) >= saveInterval else { return }
+        lastSaveAt = now
+        save()
+    }
+
+    private func add(_ seconds: Double, toBucket pct: Int) {
+        guard buckets.indices.contains(pct) else { return }
+        buckets[pct].totalSeconds += seconds
+        buckets[pct].count += 1
+    }
+
+    /// Sum of learned (or rate-derived fallback) dwell time for every bucket from
+    /// `currentPercent` down to 1, in hours. nil only if there's no curve data for any bucket
+    /// in range AND no fallback rate — mirrors `BatteryHistory.estimateHoursRemaining`'s
+    /// "no data yet" case.
+    func estimateHoursRemaining(currentPercent: Int, fallbackRatePerHour: Double?) -> Double? {
+        guard currentPercent > 0 else { return 0 }
+        let fallbackSecondsPerPercent = fallbackRatePerHour.map { 3600 / $0 }
+        var totalSeconds = 0.0
+        var hasAnyData = false
+        for pct in 1...min(currentPercent, 100) {
+            let bucket = buckets[pct]
+            if let mean = bucket.mean, bucket.count >= minSamplesToTrust {
+                totalSeconds += mean
+                hasAnyData = true
+            } else if let fallback = fallbackSecondsPerPercent {
+                totalSeconds += fallback
+            } else if let mean = bucket.mean {
+                // No fallback rate available at all — better than nothing even under-sampled.
+                totalSeconds += mean
+                hasAnyData = true
+            } else {
+                return nil // this bucket has neither learned data nor a fallback rate
+            }
+        }
+        guard hasAnyData || fallbackSecondsPerPercent != nil else { return nil }
+        return totalSeconds / 3600
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([DischargeBucket].self, from: data),
+              decoded.count == buckets.count else { return }
+        buckets = decoded
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(buckets) else { return }
+        try? data.write(to: url)
+    }
+}

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -62,6 +62,10 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     private var history = BatteryHistory(deviceKey: "default")
     private var cycleHistory = ChargeCycleHistory(deviceKey: "default")
     private var historyKey: String? // device the current history belongs to
+    /// Learned per-percent discharge curve — only set for models `RazerDevices` covers (see
+    /// `dischargeCurveModelKey`); nil leaves every other mouse on the generic rate estimate.
+    private var curveModel: DischargeCurveModel?
+    private var curveModelKey: String?
     /// Suppresses connect/disconnect sounds until the first poll establishes a baseline.
     private var hasBaseline = false
     /// io-queue only: outcome of the most recent read, and a debounce count so a single
@@ -87,8 +91,9 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         scheduleNextPoll(after: pollWhenOffline)
     }
 
-    /// Hooks `history` to log finished discharge cycles into `cycleHistory`, and republishes a
-    /// snapshot for the view. Re-run whenever `history`/`cycleHistory` are swapped for a new device.
+    /// Hooks `history` to log finished discharge cycles into `cycleHistory` and per-interval
+    /// dwell time into `curveModel`, and republishes a snapshot for the view. Re-run whenever
+    /// `history`/`cycleHistory` are swapped for a new device.
     private func wireHistory() {
         history.onCycleFinished = { [weak self] samples in
             self?.cycleHistory.recordFinishedCycle(samples: samples)
@@ -96,6 +101,11 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             let cycles = self.cycleHistory.cycles
             let avg = self.cycleHistory.averageCycleDuration.map { $0 / 3600 }
             self.publish { self.pastCycles = cycles; self.averageCycleHours = avg }
+        }
+        // Reads `self.curveModel` dynamically each call, so it stays correct even when only
+        // `curveModel` (not `history`) changes — no separate rewiring needed for that case.
+        history.onInterval = { [weak self] from, to, duration in
+            self?.curveModel?.record(fromPercent: from, toPercent: to, duration: duration)
         }
     }
 
@@ -265,7 +275,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 isCharging = false
             }
             history.record(percent: pct, charging: isCharging)
-            let estimate = isCharging ? "Charging" : history.estimateString(currentPercent: pct)
+            let estimate = isCharging ? "Charging" : history.estimateString(currentPercent: pct, curveModel: curveModel)
             let samples = history.samples
             let rate = history.currentRatePerHour
             let cycleStart = history.cycleStartedAt
@@ -390,10 +400,10 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         charging = false
         dpi = 1600
         pollRate = 1000
-        timeEstimate = "About 3 days remaining"
+        timeEstimate = "~3d 0h left (est.)" // matches BatteryHistory.estimateString's real format
         let now = Date()
         batterySamples = stride(from: 0, through: 28, by: 1).map {
-            BatterySample(t: now.addingTimeInterval(Double($0) * -3600), pct: min(100, 72 + $0))
+            BatterySample(t: now.addingTimeInterval(Double($0) * -3600), pct: min(100, 2 + $0 * 4))
         }.reversed()
         dischargeRatePerHour = 1.0
         cycleStartedAt = batterySamples.first?.t
@@ -428,6 +438,14 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         let d = try HIDDevice.open(vendorId: Razer.vendorId) // any Razer mouse
         device = d
         let pid = d.productID
+        // Model-scoped (not per-serial) discharge curve, shared across every unit of a covered
+        // model so data accumulates faster. Independent of the per-unit `historyKey` swap below
+        // since the curve key is the same across both Cobra HyperSpeed PIDs and every serial.
+        let newCurveKey = RazerDevices.dischargeCurveModelKey(pid: pid)
+        if newCurveKey != curveModelKey {
+            curveModelKey = newCurveKey
+            curveModel = newCurveKey.map { DischargeCurveModel(modelKey: $0) }
+        }
         // Per-unit key: the device's serial number if it reports one, else the PID. Lets two
         // mice of the same model keep separate settings. If the serial probe fails on a
         // reconnect (the wireless link is already known to be flaky) but we already have a

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -303,11 +303,7 @@ struct PopoverView: View {
         // No reading yet (nil) is "unknown," not "critically low" — don't flash red before the
         // first successful poll completes.
         guard let pct = controller.batteryPercent else { return .secondary }
-        switch pct {
-        case ..<15: return .batteryLow
-        case ..<40: return .batteryMid
-        default: return .batteryFull
-        }
+        return batteryLevelColor(forPercent: pct)
     }
 
     private var batteryCard: some View {

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -17,18 +17,24 @@ struct RazerDeviceInfo {
     let hasBattery: Bool
     let hasLighting: Bool
     let maxDPI: Int
+    /// Model key for the learned per-percent discharge curve (see `DischargeCurveModel`), or nil
+    /// if this model isn't covered — its cell/firmware behavior is unverified and likely
+    /// different, so it stays on the generic linear-rate estimate. Shared across every PID/
+    /// serial of a covered model (one shared key) so data accumulates faster than a per-unit or
+    /// per-PID table would.
+    let dischargeCurveModelKey: String?
 }
 
 enum RazerDevices {
     static let vendorID = 0x1532
 
     static let known: [RazerDeviceInfo] = [
-        .init(pid: 0x00DB, name: "Razer Cobra HyperSpeed", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 26000),
-        .init(pid: 0x00DA, name: "Razer Cobra HyperSpeed (Wired)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 26000),
-        .init(pid: 0x00A3, name: "Razer Cobra", fullySupported: true, hasBattery: false, hasLighting: true, maxDPI: 8500),
-        .init(pid: 0x00AF, name: "Razer Cobra Pro (Wired)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 30000),
-        .init(pid: 0x00B0, name: "Razer Cobra Pro (Wireless)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 30000),
-        .init(pid: 0x0062, name: "Razer Atheris", fullySupported: true, hasBattery: true, hasLighting: false, maxDPI: 7200),
+        .init(pid: 0x00DB, name: "Razer Cobra HyperSpeed", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 26000, dischargeCurveModelKey: "cobra-hyperspeed"),
+        .init(pid: 0x00DA, name: "Razer Cobra HyperSpeed (Wired)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 26000, dischargeCurveModelKey: "cobra-hyperspeed"),
+        .init(pid: 0x00A3, name: "Razer Cobra", fullySupported: true, hasBattery: false, hasLighting: true, maxDPI: 8500, dischargeCurveModelKey: nil),
+        .init(pid: 0x00AF, name: "Razer Cobra Pro (Wired)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 30000, dischargeCurveModelKey: nil),
+        .init(pid: 0x00B0, name: "Razer Cobra Pro (Wireless)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 30000, dischargeCurveModelKey: nil),
+        .init(pid: 0x0062, name: "Razer Atheris", fullySupported: true, hasBattery: true, hasLighting: false, maxDPI: 7200, dischargeCurveModelKey: nil),
     ]
 
     static func info(pid: Int) -> RazerDeviceInfo? { known.first { $0.pid == pid } }
@@ -37,4 +43,5 @@ enum RazerDevices {
     static func hasBattery(pid: Int) -> Bool { info(pid: pid)?.hasBattery ?? true }
     static func hasLighting(pid: Int) -> Bool { info(pid: pid)?.hasLighting ?? true }
     static func maxDPI(pid: Int) -> Int { info(pid: pid)?.maxDPI ?? 26000 }
+    static func dischargeCurveModelKey(pid: Int) -> String? { info(pid: pid)?.dischargeCurveModelKey }
 }

--- a/Sources/MacRazer/UsageGraphView.swift
+++ b/Sources/MacRazer/UsageGraphView.swift
@@ -53,17 +53,27 @@ struct UsageGraphView: View {
                     placeholder("Gathering data…")
                 } else {
                     Chart(controller.batterySamples, id: \.t) { sample in
+                        // Colored like the battery bar/gauge on the main page (low/mid/full).
+                        // A plain per-point `.foregroundStyle(Color)` doesn't segment a
+                        // LineMark in Swift Charts — every point ends up resolving to one
+                        // style for the whole line. `foregroundStyle(by:)` + a matching
+                        // `chartForegroundStyleScale` is what actually splits it into colored
+                        // segments by value.
                         LineMark(x: .value("Time", sample.t), y: .value("Battery", sample.pct))
-                            .foregroundStyle(Color.razerGreen)
+                            .foregroundStyle(by: .value("Level", Self.levelBand(sample.pct)))
                             .interpolationMethod(.monotone)
                         if hoveredSample?.t == sample.t {
                             RuleMark(x: .value("Time", sample.t))
                                 .foregroundStyle(.secondary.opacity(0.25))
                             PointMark(x: .value("Time", sample.t), y: .value("Battery", sample.pct))
-                                .foregroundStyle(Color.razerGreen)
+                                .foregroundStyle(batteryLevelColor(forPercent: sample.pct))
                                 .symbolSize(50)
                         }
                     }
+                    .chartForegroundStyleScale([
+                        Self.lowBand: Color.batteryLow, Self.midBand: Color.batteryMid, Self.fullBand: Color.batteryFull,
+                    ])
+                    .chartLegend(.hidden)
                     .chartYScale(domain: 0...100)
                     .chartXAxis { AxisMarks(values: .automatic(desiredCount: 3)) }
                     .chartYAxis { AxisMarks(values: [0, 50, 100]) }
@@ -81,6 +91,17 @@ struct UsageGraphView: View {
                     }
                 }
             }
+        }
+    }
+
+    // MARK: Level-band coloring (matches the battery bar's low/mid/full thresholds)
+
+    private static let lowBand = "Low", midBand = "Mid", fullBand = "Full"
+    private static func levelBand(_ pct: Int) -> String {
+        switch pct {
+        case ..<15: return lowBand
+        case ..<40: return midBand
+        default: return fullBand
         }
     }
 
@@ -103,9 +124,12 @@ struct UsageGraphView: View {
     }
 
     private var remainingText: String {
-        if controller.charging { return "Charging" }
-        guard let pct = controller.batteryPercent, let rate = controller.dischargeRatePerHour, rate > 0 else { return "—" }
-        return "~\(BatteryHistory.formatDuration(hours: Double(pct) / rate))"
+        // Reuse `timeEstimate` (the same value the main battery card shows) rather than
+        // recomputing percent/rate here — keeps the two displays from ever disagreeing, and
+        // automatically picks up the learned discharge-curve estimate where one applies.
+        guard let estimate = controller.timeEstimate else { return "—" }
+        if estimate == "Charging" { return estimate }
+        return estimate.replacingOccurrences(of: " left (est.)", with: "")
     }
 
     private var sinceChargeText: String {


### PR DESCRIPTION
## Summary
- Adds a per-percent learned discharge curve, specifically for the Razer Cobra HyperSpeed (wired + wireless), so the time-remaining estimate reflects the cell's actual non-linear discharge shape instead of one flat %/hour rate. Shared across every Cobra HyperSpeed unit so it learns faster; every other mouse model is unaffected.
- The usage graph now shows the *whole* charge cycle (sample cap raised from 500 to 25,000) instead of only the last ~2 hours, and the discharge curve is colored green/orange/red at the same thresholds as the main battery bar.
- Fixes a real bug caught during review: multi-hour disconnect/sleep gaps were being learned as real per-percent dwell time, corrupting the curve after as few as two such gaps.
- Throttles battery/discharge-curve disk writes to ~every 30s (was every poll tick), since the larger sample window would otherwise mean a much bigger file rewritten every 4-15 seconds.

## Test plan
- [x] `swift build` succeeds
- [x] Verified via `swift run MacRazer render-ui <path> usage` that the usage graph renders a full discharge curve colored green→orange→red at the correct thresholds
- [ ] Manual verification on real Cobra HyperSpeed hardware over a full charge cycle (the curve model needs real discharge data to confirm the learned estimate converges sensibly)