### PR TITLE
CLI permission guidance, low-battery notification, version-compare edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Added
+- **The menu bar icon shows a lightning bolt while the mouse is charging**, in place of the
+ mouse's button-split line — the same at-a-glance cue macOS gives for its own battery, so
+ you don't have to open the popover to tell. The body silhouette is unchanged, so only the
+ detail inside it swaps.
 - **A system notification fires once the mouse's battery drops below 15%** (the same
  threshold the battery card already colors red), so you don't have to open the popover to
  notice. One alert per discharge: it re-arms when the mouse is charging or the charge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ expect rough edges until 1.0.
 ### Added
 - **A system notification fires once the mouse's battery drops below 15%** (the same
  threshold the battery card already colors red), so you don't have to open the popover to
- notice. It's re-armed by charging or the reading climbing back to 15%+, so it won't repeat
- every poll while the mouse sits low.
+ notice. One alert per discharge: it re-arms when the mouse is charging or the charge
+ climbs back to 20%+, so neither the 15s poll cadence nor a one-off garbage reading can
+ repeat it. Swapping to a second mouse re-arms it for that unit.
 - **The usage chart now shows ~2 charges: the previous charge stays visible (dimmed) behind
  the current one.** Recharging no longer blanks the chart back to "Gathering data…" — the
  finished cycle's raw curve is kept (and persisted per device) and drawn as a dimmed gray
@@ -20,10 +21,17 @@ expect rough edges until 1.0.
  same thresholds as the "Past charges" log) don't replace the kept curve.
 
 ### Fixed
-- **The CLI diagnostics (`battery`, `dpi`, `poll`, `rgb`, `brightness`) now explain a missing
- Input Monitoring grant instead of printing a bare `IOHIDDeviceOpen failed: 0xe00002e2`.**
- The GUI already had this guidance (`PopoverView`/`PermissionsModel`); the CLI's
- `openDevice()` never checked for it (issue #3).
+- **The CLI diagnostics (`battery`, `dpi`, `poll`, `stages`, `rgb`, `brightness`) now explain
+ a missing Input Monitoring grant instead of printing a bare `IOHIDDeviceOpen failed:
+ 0xe00002e2`.** The GUI already had this guidance (`PopoverView`/`PermissionsModel`); no CLI
+ path checked for it. The hint distinguishes the two cases that actually differ: under
+ `swift run` the grant belongs to the *terminal*, not the SwiftPM binary. The `battery`
+ command also no longer blames the wireless dongle for what is a permissions failure.
+- **`VersionCompare` no longer reports a downgrade as an update.** Unparseable version
+ components were dropped rather than read as 0, which shifted the remaining ones left — so
+ `"v0.1.0"` parsed as `[1, 0]` and compared newer than `"0.2.0"`. `UpdateChecker` strips a
+ bare leading `v`, so this needed a differently-shaped tag to bite, but the comparison was
+ wrong regardless.
 - **A Mac sleep no longer resets the battery-usage chart.** After hours of rest a Li-ion
  cell legitimately reads a few percent *higher* on wake (voltage recovery, no charger
  involved), and any uptick of 2+ points was treated as "the mouse got recharged" — wiping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ expect rough edges until 1.0.
  climbs back to 20%+, so neither the 15s poll cadence nor a one-off garbage reading can
  repeat it. Swapping to a second mouse re-arms it for that unit, and charging back up
  withdraws the banner instead of leaving it in Notification Center. The armed state lives
- in memory, so a relaunch while the mouse is still low can alert once more.
+ in memory, so a relaunch while the mouse is still low can alert once more. If notifications
+ are switched off for MacRazer the alert stays pending rather than being silently spent, so
+ turning them on mid-discharge still gets you the warning.
 - **The usage chart now shows ~2 charges: the previous charge stays visible (dimmed) behind
  the current one.** Recharging no longer blanks the chart back to "Gathering data…" — the
  finished cycle's raw curve is kept (and persisted per device) and drawn as a dimmed gray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Added
+- **A system notification fires once the mouse's battery drops below 15%** (the same
+ threshold the battery card already colors red), so you don't have to open the popover to
+ notice. It's re-armed by charging or the reading climbing back to 15%+, so it won't repeat
+ every poll while the mouse sits low.
 - **The usage chart now shows ~2 charges: the previous charge stays visible (dimmed) behind
  the current one.** Recharging no longer blanks the chart back to "Gathering data…" — the
  finished cycle's raw curve is kept (and persisted per device) and drawn as a dimmed gray
@@ -16,6 +20,10 @@ expect rough edges until 1.0.
  same thresholds as the "Past charges" log) don't replace the kept curve.
 
 ### Fixed
+- **The CLI diagnostics (`battery`, `dpi`, `poll`, `rgb`, `brightness`) now explain a missing
+ Input Monitoring grant instead of printing a bare `IOHIDDeviceOpen failed: 0xe00002e2`.**
+ The GUI already had this guidance (`PopoverView`/`PermissionsModel`); the CLI's
+ `openDevice()` never checked for it (issue #3).
 - **A Mac sleep no longer resets the battery-usage chart.** After hours of rest a Li-ion
  cell legitimately reads a few percent *higher* on wake (voltage recovery, no charger
  involved), and any uptick of 2+ points was treated as "the mouse got recharged" — wiping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ expect rough edges until 1.0.
  threshold the battery card already colors red), so you don't have to open the popover to
  notice. One alert per discharge: it re-arms when the mouse is charging or the charge
  climbs back to 20%+, so neither the 15s poll cadence nor a one-off garbage reading can
- repeat it. Swapping to a second mouse re-arms it for that unit.
+ repeat it. Swapping to a second mouse re-arms it for that unit, and charging back up
+ withdraws the banner instead of leaving it in Notification Center. The armed state lives
+ in memory, so a relaunch while the mouse is still low can alert once more.
 - **The usage chart now shows ~2 charges: the previous charge stays visible (dimmed) behind
  the current one.** Recharging no longer blanks the chart back to "Gathering data…" — the
  finished cycle's raw curve is kept (and persisted per device) and drawn as a dimmed gray

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -30,11 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         // user without it is always walked through it rather than left with a silently-dead app.
         // Button remapping additionally needs Accessibility (optional; surfaced in the same window).
         permissions.recheck()
-        // Without a delegate, macOS suppresses our banner whenever MacRazer is the active
-        // app — and clicking the status item activates it, so a low reading while the
-        // popover is open would consume the one alert and show nothing.
-        UNUserNotificationCenter.current().delegate = self
-        LowBatteryNotifier.requestAuthorizationIfNeeded()
+        LowBatteryNotifier.configureNotifications(delegate: self)
         // A manual button-remap edit (outside applying a profile) means the live config no
         // longer matches whichever profile was last applied — let MouseController know so it
         // can drop the stale "active" highlight.

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -4,11 +4,12 @@
 import AppKit
 import SwiftUI
 import Combine
+import UserNotifications
 
 /// Menu bar (accessory) app: an NSStatusItem showing battery %, click opens an NSPopover
 /// hosting the SwiftUI controls. Mirrors the pattern macOS's own Bluetooth/Battery menus use.
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNUserNotificationCenterDelegate {
     private var statusItem: NSStatusItem!
     private let popover = NSPopover()
     private let controller = MouseController()
@@ -29,6 +30,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // user without it is always walked through it rather than left with a silently-dead app.
         // Button remapping additionally needs Accessibility (optional; surfaced in the same window).
         permissions.recheck()
+        // Without a delegate, macOS suppresses our banner whenever MacRazer is the active
+        // app — and clicking the status item activates it, so a low reading while the
+        // popover is open would consume the one alert and show nothing.
+        UNUserNotificationCenter.current().delegate = self
         LowBatteryNotifier.requestAuthorizationIfNeeded()
         // A manual button-remap edit (outside applying a profile) means the live config no
         // longer matches whichever profile was last applied — let MouseController know so it
@@ -265,6 +270,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         monitor?.invalidate()
         updateTimer?.invalidate()
         controller.flushHistoryToDisk()
+    }
+
+    // MARK: - Notifications
+
+    /// Present the low-battery banner even while MacRazer is frontmost (the default is to
+    /// suppress it, which would silently swallow the alert).
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
     }
 
     // MARK: - Input Monitoring permission

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -270,6 +270,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     /// a grant in System Settings and switched back, so the setup window reflects it live.
     func applicationDidBecomeActive(_ notification: Notification) {
         permissions.recheck()
+        // Same reason as the permission recheck: the user may have just flipped the
+        // Notifications switch in System Settings and come back.
+        controller.refreshNotificationAuthorization()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -44,8 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         }
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let icon = MenuBarIcon.mouse(pointSize: 21, razerCutout: false)
-        statusItem.button?.image = icon
+        statusItem.button?.image = Self.menuBarIcon(charging: false)
         statusItem.button?.imagePosition = .imageLeading
         statusItem.button?.imageHugsTitle = true
         statusItem.button?.title = " …"
@@ -80,6 +79,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] text in self?.statusItem.button?.title = text }
+            .store(in: &cancellables)
+
+        // Swap the mark for its bolt variant while the mouse is on the charger — the same
+        // at-a-glance cue macOS gives for its own battery, without needing the popover.
+        // Only the two states exist, so the images are cached rather than redrawn per event.
+        controller.$charging
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] charging in
+                self?.statusItem.button?.image = Self.menuBarIcon(charging: charging)
+            }
             .store(in: &cancellables)
 
         // When disconnected, keep the icon's normal adaptive (template) colour but dim it via
@@ -271,6 +281,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         updateTimer?.invalidate()
         controller.flushHistoryToDisk()
     }
+
+    // MARK: - Menu bar mark
+
+    /// The status-item mark, in its idle and charging variants. Drawing is cheap but this
+    /// runs on every charge-state change for the app's lifetime, so both are built once.
+    private static let idleIcon = MenuBarIcon.mouse(pointSize: 21, razerCutout: false)
+    private static let chargingIcon = MenuBarIcon.mouse(pointSize: 21, razerCutout: false, charging: true)
+    private static func menuBarIcon(charging: Bool) -> NSImage { charging ? chargingIcon : idleIcon }
 
     // MARK: - Notifications
 

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // user without it is always walked through it rather than left with a silently-dead app.
         // Button remapping additionally needs Accessibility (optional; surfaced in the same window).
         permissions.recheck()
+        LowBatteryNotifier.requestAuthorizationIfNeeded()
         // A manual button-remap edit (outside applying a profile) means the live config no
         // longer matches whichever profile was last applied — let MouseController know so it
         // can drop the stale "active" highlight.

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -19,11 +19,16 @@ func sectionLabel(_ text: String, _ symbol: String) -> some View {
         .foregroundStyle(.secondary)
 }
 
+/// The "low battery" cutoff shared by every consumer that needs to agree on it: this file's
+/// color band, the battery-percent readout in PopoverView, and LowBatteryNotifier's alert.
+/// One constant so they can't silently drift apart.
+let batteryLowThresholdPercent = 15
+
 /// Battery-state color for a given percent — the same low/mid/full thresholds as the battery
 /// card's level bar and gauge, shared so the usage graph's discharge curve matches it exactly.
 func batteryLevelColor(forPercent pct: Int) -> Color {
     switch pct {
-    case ..<15: return .batteryLow
+    case ..<batteryLowThresholdPercent: return .batteryLow
     case ..<40: return .batteryMid
     default: return .batteryFull
     }

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -19,13 +19,28 @@ func sectionLabel(_ text: String, _ symbol: String) -> some View {
         .foregroundStyle(.secondary)
 }
 
+/// The battery-percentage bands, in one place so every consumer agrees: this file's colour
+/// helper, the percent readout in PopoverView, the usage chart's curve bands, and the
+/// low-battery alert.
+enum Battery {
+    /// Below this the battery reads as "low" — red gauge/readout/curve, and the one
+    /// `LowBatteryAlertPolicy` notification.
+    static let lowThresholdPercent = 15
+    /// Below this (and at or above `lowThresholdPercent`) is the amber middle band.
+    static let midThresholdPercent = 40
+    /// The alert re-arms only once the charge climbs back to here — deliberately above
+    /// `lowThresholdPercent`. Without that gap, one garbage-but-accepted high reading (the
+    /// poll state machine adopts a third consecutive outlier as the new baseline) would
+    /// re-arm and let the next genuine low reading fire a duplicate alert.
+    static let lowRearmPercent = 20
+}
+
 /// Battery-state color for a given percent — the same low/mid/full thresholds as the battery
 /// card's level bar and gauge, shared so the usage graph's discharge curve matches it exactly.
-/// The low cutoff lives on `Battery` (see LowBatteryNotifier.swift) so the alert agrees too.
 func batteryLevelColor(forPercent pct: Int) -> Color {
     switch pct {
     case ..<Battery.lowThresholdPercent: return .batteryLow
-    case ..<40: return .batteryMid
+    case ..<Battery.midThresholdPercent: return .batteryMid
     default: return .batteryFull
     }
 }

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -19,16 +19,12 @@ func sectionLabel(_ text: String, _ symbol: String) -> some View {
         .foregroundStyle(.secondary)
 }
 
-/// The "low battery" cutoff shared by every consumer that needs to agree on it: this file's
-/// color band, the battery-percent readout in PopoverView, and LowBatteryNotifier's alert.
-/// One constant so they can't silently drift apart.
-let batteryLowThresholdPercent = 15
-
 /// Battery-state color for a given percent — the same low/mid/full thresholds as the battery
 /// card's level bar and gauge, shared so the usage graph's discharge curve matches it exactly.
+/// The low cutoff lives on `Battery` (see LowBatteryNotifier.swift) so the alert agrees too.
 func batteryLevelColor(forPercent pct: Int) -> Color {
     switch pct {
-    case ..<batteryLowThresholdPercent: return .batteryLow
+    case ..<Battery.lowThresholdPercent: return .batteryLow
     case ..<40: return .batteryMid
     default: return .batteryFull
     }

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+import UserNotifications
+
+/// Fires a system notification once when the mouse's battery drops below the same
+/// threshold the UI itself already treats as "low" (see `Color.batteryLow`, <15%).
+///
+/// One notification per discharge episode: charging or a reading back at/above the
+/// threshold re-arms it, so the ~15s poll cadence can't repeat the same alert every tick.
+final class LowBatteryNotifier {
+    static let threshold = 15
+    private var armed = true
+
+    /// Ask for notification permission once, early — so the system prompt appears at
+    /// launch rather than the first time the battery happens to be low. No-op under
+    /// `swift run` (no bundle identifier there — same dev-mode carve-out as `relaunch()`
+    /// in Permissions.swift): UNUserNotificationCenter needs a real app bundle.
+    static func requestAuthorizationIfNeeded() {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    /// Call on every battery reading. Charging or climbing back to/above the threshold
+    /// re-arms the notification for the next time the mouse drops low.
+    func notify(deviceName: String?, percent: Int, charging: Bool) {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        guard !charging, percent < Self.threshold else {
+            armed = true
+            return
+        }
+        guard armed else { return }
+        armed = false
+
+        let content = UNMutableNotificationContent()
+        content.title = "Battery Low"
+        content.body = "\(deviceName ?? "Razer mouse") is at \(percent)% — charge it soon."
+        content.sound = .default
+        let request = UNNotificationRequest(identifier: "low-battery", content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -4,19 +4,6 @@
 import Foundation
 import UserNotifications
 
-/// Battery percentage thresholds shared across the UI and the low-battery alert, so the
-/// colour bands, the percent readout and the notification can't drift apart.
-enum Battery {
-    /// Below this, the battery reads as "low": the gauge, the percent readout and the usage
-    /// chart's band turn red, and `LowBatteryAlertPolicy` fires its one notification.
-    static let lowThresholdPercent = 15
-    /// The alert re-arms only once the charge climbs back to here — deliberately above
-    /// `lowThresholdPercent`. Without that gap, one garbage-but-accepted high reading (the
-    /// poll state machine adopts a third consecutive outlier as the new baseline) would
-    /// re-arm and let the next genuine low reading fire a duplicate alert.
-    static let lowRearmPercent = 20
-}
-
 /// The pure decision core of the low-battery alert: given a reading, should we alert?
 ///
 /// Split from delivery (`LowBatteryNotifier`) for the same reason as
@@ -25,6 +12,10 @@ enum Battery {
 struct LowBatteryAlertPolicy {
     private var armed = true
 
+    /// Whether the next qualifying low reading would alert. Read by the notifier to spot the
+    /// re-arm edge (so it can withdraw an already-delivered banner).
+    var isArmed: Bool { armed }
+
     /// A different physical mouse was bound, so this unit has never been alerted on.
     /// Deliberately NOT called for the same-session PID→serial key upgrade, which renames
     /// the *same* unit's storage — re-arming there would duplicate its alert.
@@ -32,22 +23,30 @@ struct LowBatteryAlertPolicy {
 
     /// Feed every battery reading. Returns true at most once per discharge episode.
     ///
-    /// `charging` must be the *observed* charging flag, not `BatteryPollStateMachine`'s
+    /// `charging` must be the *observed* flag, not `BatteryPollStateMachine`'s
     /// two-poll-confirmed one: that confirmation resets on any transient read failure, so a
     /// docked mouse reports "not charging" on the first good poll after one — which would
     /// fire a false "charge it soon" while it sits on the charger.
-    mutating func shouldAlert(percent: Int, charging: Bool) -> Bool {
-        if charging || percent >= Battery.lowRearmPercent {
+    ///
+    /// `nil` means the charging read itself failed. That is *not* "on battery": the mouse
+    /// refuses commands around sleep exactly when it's most likely docked, so treating a
+    /// failed read as discharging is the same false alert by another route. Unknown neither
+    /// alerts nor re-arms — the next successful read decides.
+    mutating func shouldAlert(percent: Int, charging: Bool?) -> Bool {
+        if charging == true || percent >= Battery.lowRearmPercent {
             armed = true
             return false
         }
+        guard charging == false else { return false }
         guard percent < Battery.lowThresholdPercent, armed else { return false }
         armed = false
         return true
     }
 
-    /// Delivery failed (notifications denied or undeliverable) — put the alert back so this
-    /// discharge episode isn't silently skipped.
+    /// Delivery failed transiently — put the alert back so this discharge episode isn't
+    /// silently skipped. Permanent refusals (notifications switched off for the app) must
+    /// NOT come through here: re-arming on those turns one denied alert into an attempt and
+    /// a log line on every poll for the whole low-battery period.
     mutating func rearmAfterFailedDelivery() { armed = true }
 }
 
@@ -59,13 +58,22 @@ struct LowBatteryAlertPolicy {
 final class LowBatteryNotifier: @unchecked Sendable {
     private var policy = LowBatteryAlertPolicy()
 
-    /// Ask for notification permission once, early — so the system prompt appears at launch
-    /// rather than the first time the battery happens to be low. No-op under `swift run`
-    /// (no bundle identifier there, the same dev-mode carve-out as `PermissionsModel.relaunch()`):
-    /// UNUserNotificationCenter needs a real app bundle.
-    static func requestAuthorizationIfNeeded() {
+    /// Set the presentation delegate and ask for permission once, early — so the system
+    /// prompt appears at launch rather than the first time the battery happens to be low.
+    ///
+    /// Whole thing is a no-op under `swift run` (the same dev-mode carve-out as
+    /// `PermissionsModel.relaunch()`). The guard covers `UNUserNotificationCenter.current()`
+    /// itself, not just what we do with it: with no app bundle it raises
+    /// NSInternalInconsistencyException ("bundleProxyForCurrentProcess is nil") and takes
+    /// the whole app down at launch — and `swift run MacRazer` is a documented dev path.
+    static func configureNotifications(delegate: UNUserNotificationCenterDelegate) {
         guard Bundle.main.bundleIdentifier != nil else { return }
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+        let center = UNUserNotificationCenter.current()
+        // Without a delegate, macOS suppresses the banner whenever MacRazer is frontmost —
+        // and clicking the status item activates it, so a low reading while the popover is
+        // open would consume the one alert and show nothing.
+        center.delegate = delegate
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
                 FileHandle.standardError.write(Data("[MacRazer] notification authorization failed: \(error)\n".utf8))
             } else if !granted {
@@ -78,8 +86,15 @@ final class LowBatteryNotifier: @unchecked Sendable {
 
     /// Call on every battery reading. `deviceKey` scopes the notification so two mice each
     /// hold their own alert instead of one silently replacing the other.
-    func notify(deviceKey: String?, deviceName: String?, percent: Int, charging: Bool) {
-        guard policy.shouldAlert(percent: percent, charging: charging) else { return }
+    func notify(deviceKey: String?, deviceName: String?, percent: Int, charging: Bool?) {
+        let wasArmed = policy.isArmed
+        guard policy.shouldAlert(percent: percent, charging: charging) else {
+            // Re-armed on this tick (charged back up) — drop the delivered banner too, or
+            // "is at 12% — charge it soon" sits in Notification Center for days after the
+            // mouse is full.
+            if !wasArmed, policy.isArmed { withdrawDelivered(deviceKey: deviceKey) }
+            return
+        }
         // The policy runs regardless of bundle (so dev runs still exercise it); only
         // delivery needs a real app bundle.
         guard Bundle.main.bundleIdentifier != nil else { return }
@@ -89,7 +104,7 @@ final class LowBatteryNotifier: @unchecked Sendable {
         content.body = "\(deviceName ?? "Razer mouse") is at \(percent)% — charge it soon."
         content.sound = .default
         let request = UNNotificationRequest(
-            identifier: "low-battery-\(deviceKey ?? "unknown")", content: content, trigger: nil)
+            identifier: Self.identifier(deviceKey: deviceKey), content: content, trigger: nil)
         // Built before the delivery callback so the callback itself never captures `self`.
         // Never delivered → don't burn this discharge episode's one alert; the hop back to
         // the main queue is what keeps `policy` main-queue-owned.
@@ -99,7 +114,18 @@ final class LowBatteryNotifier: @unchecked Sendable {
         UNUserNotificationCenter.current().add(request) { error in
             guard let error else { return }
             FileHandle.standardError.write(Data("[MacRazer] low-battery notification failed: \(error)\n".utf8))
+            // Notifications switched off for the app is permanent for this run: re-arming
+            // would retry (and log) every poll for the whole low-battery period.
+            if (error as? UNError)?.code == .notificationsNotAllowed { return }
             rearm()
         }
     }
+
+    private func withdrawDelivered(deviceKey: String?) {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        UNUserNotificationCenter.current()
+            .removeDeliveredNotifications(withIdentifiers: [Self.identifier(deviceKey: deviceKey)])
+    }
+
+    private static func identifier(deviceKey: String?) -> String { "low-battery-\(deviceKey ?? "unknown")" }
 }

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -4,46 +4,102 @@
 import Foundation
 import UserNotifications
 
-/// Fires a system notification once when the mouse's battery drops below
-/// `batteryLowThresholdPercent` — the same cutoff the UI itself already treats as "low".
+/// Battery percentage thresholds shared across the UI and the low-battery alert, so the
+/// colour bands, the percent readout and the notification can't drift apart.
+enum Battery {
+    /// Below this, the battery reads as "low": the gauge, the percent readout and the usage
+    /// chart's band turn red, and `LowBatteryAlertPolicy` fires its one notification.
+    static let lowThresholdPercent = 15
+    /// The alert re-arms only once the charge climbs back to here — deliberately above
+    /// `lowThresholdPercent`. Without that gap, one garbage-but-accepted high reading (the
+    /// poll state machine adopts a third consecutive outlier as the new baseline) would
+    /// re-arm and let the next genuine low reading fire a duplicate alert.
+    static let lowRearmPercent = 20
+}
+
+/// The pure decision core of the low-battery alert: given a reading, should we alert?
 ///
-/// One notification per discharge episode: charging or a reading back at/above the
-/// threshold re-arms it, so the ~15s poll cadence can't repeat the same alert every tick.
-final class LowBatteryNotifier {
+/// Split from delivery (`LowBatteryNotifier`) for the same reason as
+/// `BatteryPollStateMachine` — no I/O, no clock, no bundle — so every arm/re-arm edge is
+/// unit-testable by replaying readings.
+struct LowBatteryAlertPolicy {
     private var armed = true
 
-    /// Ask for notification permission once, early — so the system prompt appears at
-    /// launch rather than the first time the battery happens to be low. No-op under
-    /// `swift run` (no bundle identifier there — same dev-mode carve-out as `relaunch()`
-    /// in Permissions.swift): UNUserNotificationCenter needs a real app bundle.
+    /// A different physical mouse was bound, so this unit has never been alerted on.
+    /// Deliberately NOT called for the same-session PID→serial key upgrade, which renames
+    /// the *same* unit's storage — re-arming there would duplicate its alert.
+    mutating func deviceChanged() { armed = true }
+
+    /// Feed every battery reading. Returns true at most once per discharge episode.
+    ///
+    /// `charging` must be the *observed* charging flag, not `BatteryPollStateMachine`'s
+    /// two-poll-confirmed one: that confirmation resets on any transient read failure, so a
+    /// docked mouse reports "not charging" on the first good poll after one — which would
+    /// fire a false "charge it soon" while it sits on the charger.
+    mutating func shouldAlert(percent: Int, charging: Bool) -> Bool {
+        if charging || percent >= Battery.lowRearmPercent {
+            armed = true
+            return false
+        }
+        guard percent < Battery.lowThresholdPercent, armed else { return false }
+        armed = false
+        return true
+    }
+
+    /// Delivery failed (notifications denied or undeliverable) — put the alert back so this
+    /// discharge episode isn't silently skipped.
+    mutating func rearmAfterFailedDelivery() { armed = true }
+}
+
+/// Delivers the low-battery alert.
+///
+/// `@unchecked Sendable` under the same discipline as `MouseController`, which owns it:
+/// `policy` is touched only on the main queue (every call site is inside a `publish` block),
+/// so it needs no synchronisation — the delivery callback hops back before re-arming.
+final class LowBatteryNotifier: @unchecked Sendable {
+    private var policy = LowBatteryAlertPolicy()
+
+    /// Ask for notification permission once, early — so the system prompt appears at launch
+    /// rather than the first time the battery happens to be low. No-op under `swift run`
+    /// (no bundle identifier there, the same dev-mode carve-out as `PermissionsModel.relaunch()`):
+    /// UNUserNotificationCenter needs a real app bundle.
     static func requestAuthorizationIfNeeded() {
         guard Bundle.main.bundleIdentifier != nil else { return }
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
-    }
-
-    /// Re-arms the notification for a newly-connected physical mouse — otherwise a unit
-    /// swap (two mice sharing a session) would inherit the previous mouse's "already
-    /// notified" state and stay silent even though this one was never alerted on.
-    func deviceChanged() {
-        armed = true
-    }
-
-    /// Call on every battery reading. Charging or climbing back to/above the threshold
-    /// re-arms the notification for the next time the mouse drops low.
-    func notify(deviceName: String?, percent: Int, charging: Bool) {
-        guard Bundle.main.bundleIdentifier != nil else { return }
-        guard !charging, percent < batteryLowThresholdPercent else {
-            armed = true
-            return
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                FileHandle.standardError.write(Data("[MacRazer] notification authorization failed: \(error)\n".utf8))
+            } else if !granted {
+                FileHandle.standardError.write(Data("[MacRazer] notifications not permitted — low-battery alerts are off\n".utf8))
+            }
         }
-        guard armed else { return }
-        armed = false
+    }
+
+    func deviceChanged() { policy.deviceChanged() }
+
+    /// Call on every battery reading. `deviceKey` scopes the notification so two mice each
+    /// hold their own alert instead of one silently replacing the other.
+    func notify(deviceKey: String?, deviceName: String?, percent: Int, charging: Bool) {
+        guard policy.shouldAlert(percent: percent, charging: charging) else { return }
+        // The policy runs regardless of bundle (so dev runs still exercise it); only
+        // delivery needs a real app bundle.
+        guard Bundle.main.bundleIdentifier != nil else { return }
 
         let content = UNMutableNotificationContent()
         content.title = "Battery Low"
         content.body = "\(deviceName ?? "Razer mouse") is at \(percent)% — charge it soon."
         content.sound = .default
-        let request = UNNotificationRequest(identifier: "low-battery", content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request)
+        let request = UNNotificationRequest(
+            identifier: "low-battery-\(deviceKey ?? "unknown")", content: content, trigger: nil)
+        // Built before the delivery callback so the callback itself never captures `self`.
+        // Never delivered → don't burn this discharge episode's one alert; the hop back to
+        // the main queue is what keeps `policy` main-queue-owned.
+        let rearm: @Sendable () -> Void = { [weak self] in
+            DispatchQueue.main.async { self?.policy.rearmAfterFailedDelivery() }
+        }
+        UNUserNotificationCenter.current().add(request) { error in
+            guard let error else { return }
+            FileHandle.standardError.write(Data("[MacRazer] low-battery notification failed: \(error)\n".utf8))
+            rearm()
+        }
     }
 }

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -57,6 +57,14 @@ struct LowBatteryAlertPolicy {
 /// so it needs no synchronisation — the delivery callback hops back before re-arming.
 final class LowBatteryNotifier: @unchecked Sendable {
     private var policy = LowBatteryAlertPolicy()
+    /// Cached notification authorization, main-queue owned. nil until the first check.
+    ///
+    /// Consulted *before* the policy so a denial can't silently burn this discharge's one
+    /// alert: `add()` reports success even when notifications are switched off for the app
+    /// (verified on macOS 26 — authorizationStatus .denied, add() completion error nil), so
+    /// the delivery callback can't be the place this is caught.
+    private var authorized: Bool?
+    private var loggedDenial = false
 
     /// Set the presentation delegate and ask for permission once, early — so the system
     /// prompt appears at launch rather than the first time the battery happens to be low.
@@ -84,9 +92,35 @@ final class LowBatteryNotifier: @unchecked Sendable {
 
     func deviceChanged() { policy.deviceChanged() }
 
+    /// Re-read whether the user has allowed notifications. Called at launch and whenever the
+    /// app returns to the foreground, so toggling the setting takes effect without a restart.
+    func refreshAuthorization() {
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        // Built outside the callback so the callback never captures `self` (same reason as
+        // the delivery re-arm below).
+        let apply: @Sendable (Bool) -> Void = { [weak self] ok in
+            DispatchQueue.main.async { self?.authorized = ok }
+        }
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            apply(settings.authorizationStatus == .authorized
+                  || settings.authorizationStatus == .provisional)
+        }
+    }
+
     /// Call on every battery reading. `deviceKey` scopes the notification so two mice each
     /// hold their own alert instead of one silently replacing the other.
     func notify(deviceKey: String?, deviceName: String?, percent: Int, charging: Bool?) {
+        // Denied: leave the policy untouched so the alert is still pending if the user turns
+        // notifications on mid-discharge. Logged once — this runs on every poll.
+        if authorized == false {
+            if !loggedDenial {
+                loggedDenial = true
+                let msg = "[MacRazer] notifications are off for MacRazer — low-battery alerts "
+                    + "won't appear (System Settings › Notifications › MacRazer)\n"
+                FileHandle.standardError.write(Data(msg.utf8))
+            }
+            return
+        }
         let wasArmed = policy.isArmed
         guard policy.shouldAlert(percent: percent, charging: charging) else {
             // Re-armed on this tick (charged back up) — drop the delivered banner too, or

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -4,13 +4,12 @@
 import Foundation
 import UserNotifications
 
-/// Fires a system notification once when the mouse's battery drops below the same
-/// threshold the UI itself already treats as "low" (see `Color.batteryLow`, <15%).
+/// Fires a system notification once when the mouse's battery drops below
+/// `batteryLowThresholdPercent` — the same cutoff the UI itself already treats as "low".
 ///
 /// One notification per discharge episode: charging or a reading back at/above the
 /// threshold re-arms it, so the ~15s poll cadence can't repeat the same alert every tick.
 final class LowBatteryNotifier {
-    static let threshold = 15
     private var armed = true
 
     /// Ask for notification permission once, early — so the system prompt appears at
@@ -22,11 +21,18 @@ final class LowBatteryNotifier {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
 
+    /// Re-arms the notification for a newly-connected physical mouse — otherwise a unit
+    /// swap (two mice sharing a session) would inherit the previous mouse's "already
+    /// notified" state and stay silent even though this one was never alerted on.
+    func deviceChanged() {
+        armed = true
+    }
+
     /// Call on every battery reading. Charging or climbing back to/above the threshold
     /// re-arms the notification for the next time the mouse drops low.
     func notify(deviceName: String?, percent: Int, charging: Bool) {
         guard Bundle.main.bundleIdentifier != nil else { return }
-        guard !charging, percent < Self.threshold else {
+        guard !charging, percent < batteryLowThresholdPercent else {
             armed = true
             return
         }

--- a/Sources/MacRazer/MenuBarIcon.swift
+++ b/Sources/MacRazer/MenuBarIcon.swift
@@ -94,8 +94,8 @@ enum MenuBarIcon {
             if charging {
                 // Classic 6-point flash, in units of the bolt's own half-width/half-height
                 // so the proportions hold at any icon size.
-                let bw = 0.16, bh = 0.145, yOff: CGFloat = 0.015
-                func B(_ x: CGFloat, _ y: CGFloat) -> CGPoint { P(x * bw, y * bh + yOff) }
+                let boltHalfW = 0.16, boltHalfH = 0.145, yOff: CGFloat = 0.015
+                func B(_ x: CGFloat, _ y: CGFloat) -> CGPoint { P(x * boltHalfW, y * boltHalfH + yOff) }
                 let bolt = CGMutablePath()
                 bolt.move(to: B(0.35, 1.00))     // top tip
                 bolt.addLine(to: B(-0.55, 0.05)) // down-left to the waist
@@ -159,8 +159,9 @@ enum MenuBarIcon {
     }
 
     /// Render a mark to a PNG file (used by the `icon` CLI command for visual verification).
+    @discardableResult
     static func writePreview(to path: String, size: CGFloat, silhouette: RazerMouseSilhouette = .cobra,
-                             razerCutout: Bool = true, charging: Bool = false) {
+                             razerCutout: Bool = true, charging: Bool = false) -> Bool {
         let image = drawMouse(size: size, razerCutout: razerCutout, silhouette: silhouette,
                               color: NSColor(red: 0x44/255, green: 0xD6/255, blue: 0x2C/255, alpha: 1),
                               charging: charging)
@@ -169,7 +170,7 @@ enum MenuBarIcon {
             bitmapDataPlanes: nil, pixelsWide: px, pixelsHigh: px,
             bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
             colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
-        ) else { return }
+        ) else { return false }
 
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
@@ -179,7 +180,13 @@ enum MenuBarIcon {
         image.draw(in: NSRect(x: 0, y: 0, width: CGFloat(px), height: CGFloat(px)))
         NSGraphicsContext.restoreGraphicsState()
 
-        guard let data = rep.representation(using: .png, properties: [:]) else { return }
-        try? data.write(to: URL(fileURLWithPath: path))
+        guard let data = rep.representation(using: .png, properties: [:]) else { return false }
+        do {
+            try data.write(to: URL(fileURLWithPath: path))
+            return true
+        } catch {
+            FileHandle.standardError.write(Data("[MacRazer] icon write failed: \(error)\n".utf8))
+            return false
+        }
     }
 }

--- a/Sources/MacRazer/MenuBarIcon.swift
+++ b/Sources/MacRazer/MenuBarIcon.swift
@@ -8,9 +8,9 @@ import AppKit
 enum MenuBarIcon {
 
     /// A mouse silhouette with a small Razer triskelion cut into the body (even-odd).
-    /// Template image for the menu bar.
-    static func mouse(pointSize: CGFloat = 16, razerCutout: Bool = true) -> NSImage {
-        let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: .cobra)
+    /// Template image for the menu bar. `charging` swaps the button-split line for a bolt.
+    static func mouse(pointSize: CGFloat = 16, razerCutout: Bool = true, charging: Bool = false) -> NSImage {
+        let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: .cobra, charging: charging)
         img.isTemplate = true
         return img
     }
@@ -18,13 +18,17 @@ enum MenuBarIcon {
     /// Same silhouette family, but shaped/detailed to match the specific connected model
     /// (by USB product ID) instead of always drawing the generic Cobra body. Falls back to
     /// the generic Cobra shape for an unknown or absent device.
+    /// No charging variant here on purpose: this is the popover's header mark, and the card
+    /// directly below it already spells out the charging state in words.
     static func mouseModel(pid: Int?, razerCutout: Bool = true, pointSize: CGFloat = 20) -> NSImage {
-        let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: RazerDevices.silhouette(pid: pid))
+        let img = drawMouse(size: pointSize, razerCutout: razerCutout,
+                            silhouette: RazerDevices.silhouette(pid: pid))
         img.isTemplate = true
         return img
     }
 
-    private static func drawMouse(size s: CGFloat, razerCutout: Bool, silhouette: RazerMouseSilhouette, color: NSColor = .black) -> NSImage {
+    private static func drawMouse(size s: CGFloat, razerCutout: Bool, silhouette: RazerMouseSilhouette,
+                                  color: NSColor = .black, charging: Bool = false) -> NSImage {
         NSImage(size: NSSize(width: s, height: s), flipped: false) { rect in
             guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
             let cx = rect.midX, cy = rect.midY
@@ -62,9 +66,12 @@ enum MenuBarIcon {
                                cornerWidth: wheelW / 2, cornerHeight: wheelW / 2, transform: nil)
             ctx.addPath(wheel)
 
-            // Button-split line below the wheel.
-            ctx.move(to: P(0, 0.13))
-            ctx.addLine(to: P(0, -0.10))
+            // Button-split line below the wheel — replaced by a charging bolt in the same
+            // slot, so the body silhouette stays identical and only the detail changes.
+            if !charging {
+                ctx.move(to: P(0, 0.13))
+                ctx.addLine(to: P(0, -0.10))
+            }
 
             // Thumb buttons on the left edge: two on Cobra/Cobra Pro, one on the smaller Atheris.
             let bw = s * 0.115, bh = s * 0.072
@@ -80,6 +87,27 @@ enum MenuBarIcon {
                 ctx.addPath(CGPath(roundedRect: dpi, cornerWidth: s * 0.025, cornerHeight: s * 0.025, transform: nil))
             }
             ctx.strokePath()
+
+            // Charging bolt, filled rather than stroked: at menu bar size a stroked outline
+            // closes up into a blob, while a solid glyph stays legible. Drawn after
+            // `strokePath` so it isn't caught by the body's stroke.
+            if charging {
+                // Classic 6-point flash, in units of the bolt's own half-width/half-height
+                // so the proportions hold at any icon size.
+                let bw = 0.16, bh = 0.145, yOff: CGFloat = 0.015
+                func B(_ x: CGFloat, _ y: CGFloat) -> CGPoint { P(x * bw, y * bh + yOff) }
+                let bolt = CGMutablePath()
+                bolt.move(to: B(0.35, 1.00))     // top tip
+                bolt.addLine(to: B(-0.55, 0.05)) // down-left to the waist
+                bolt.addLine(to: B(0.00, 0.05))  // jog back to centre
+                bolt.addLine(to: B(-0.35, -1.00))// bottom tip
+                bolt.addLine(to: B(0.55, -0.05)) // up-right to the waist
+                bolt.addLine(to: B(0.00, -0.05)) // jog back to centre
+                bolt.closeSubpath()
+                ctx.addPath(bolt)
+                ctx.setFillColor(color.cgColor)
+                ctx.fillPath()
+            }
 
             // Triskelion mark near the base.
             if razerCutout {
@@ -131,8 +159,11 @@ enum MenuBarIcon {
     }
 
     /// Render a mark to a PNG file (used by the `icon` CLI command for visual verification).
-    static func writePreview(to path: String, size: CGFloat, silhouette: RazerMouseSilhouette = .cobra, razerCutout: Bool = true) {
-        let image = drawMouse(size: size, razerCutout: razerCutout, silhouette: silhouette, color: NSColor(red: 0x44/255, green: 0xD6/255, blue: 0x2C/255, alpha: 1))
+    static func writePreview(to path: String, size: CGFloat, silhouette: RazerMouseSilhouette = .cobra,
+                             razerCutout: Bool = true, charging: Bool = false) {
+        let image = drawMouse(size: size, razerCutout: razerCutout, silhouette: silhouette,
+                              color: NSColor(red: 0x44/255, green: 0xD6/255, blue: 0x2C/255, alpha: 1),
+                              charging: charging)
         let px = Int(size)
         guard let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil, pixelsWide: px, pixelsHigh: px,

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -222,12 +222,15 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     private func readBatterySync(immediateOffline: Bool = false) {
         let outcome: BatteryPollStateMachine.ReadOutcome
         var errText: String?
-        /// The charging flag exactly as the device reported it this tick. The verdict's
-        /// `isCharging` is the two-poll-*confirmed* one, which resets on any transient read
-        /// failure — so a docked mouse looks "not charging" on the first good poll after
-        /// one. That's harmless for the history reset the confirmation guards, but it would
-        /// fire a false "battery low, charge it soon" while the mouse sits on the charger.
-        var observedCharging = false
+        /// The charging flag as the device reported it this tick, or nil when the charging
+        /// read itself failed. The verdict's `isCharging` is the two-poll-*confirmed* one,
+        /// which resets on any transient read failure — so a docked mouse looks "not
+        /// charging" on the first good poll after one. That's harmless for the history reset
+        /// the confirmation guards, but it would fire a false "battery low" while the mouse
+        /// sits on the charger, and blink the menu bar bolt off for a whole poll cycle.
+        /// Nil is kept distinct from false: the mouse refuses commands around sleep exactly
+        /// when it's most likely docked, so "read failed" must not read as "on battery".
+        var observedCharging: Bool?
         do {
             let dev = try ensureDevice()
             if !ioHasBattery {
@@ -257,9 +260,11 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 // counts as not-charging. (A garbage-rejected tick still pays for the extra
                 // command — bounded at two ticks per episode, not worth pre-empting the
                 // state machine's decision here.)
-                let charging = raw != 0
-                    && ((try? dev.sendWithRetry(RazerCommands.getChargingStatus()))?.arguments[1] ?? 0) != 0
-                observedCharging = charging
+                // raw == 0 is the grace tick (device refused the level read): no charging
+                // query is issued, so the state is genuinely unknown rather than false.
+                let chargeReply = raw == 0 ? nil : try? dev.sendWithRetry(RazerCommands.getChargingStatus())
+                observedCharging = raw == 0 ? nil : chargeReply.map { $0.arguments[1] != 0 }
+                let charging = observedCharging ?? false
                 outcome = .battery(raw: raw, charging: charging)
             }
         } catch {
@@ -273,7 +278,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
 
         switch pollState.handle(outcome, immediateOffline: immediateOffline) {
         case .aliveNoBattery:
-            publishConnected { self.update(\.batteryPercent, nil) }
+            // A battery-less (wired) mouse can't be charging — without this the menu bar
+            // bolt survives a swap from a charging wireless mouse and never clears.
+            publishConnected {
+                self.update(\.batteryPercent, nil)
+                self.update(\.charging, false)
+            }
 
         case .notReady:
             // Keep the last known value on screen; the fast poll cadence retries shortly.
@@ -289,7 +299,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 // apply" banner would now be lying (polls clear it within ~15s of a wake).
                 self.update(\.profileApplyFailed, false)
                 self.update(\.batteryPercent, pct)
-                self.update(\.charging, isCharging)
+                // Published for display (menu bar bolt, popover badge) off the *observed*
+                // flag, not the debounced one: the debounce exists to guard the destructive
+                // history reset below, and applying it here blinks the bolt off for a full
+                // poll cycle after any transient failure. An unknown read holds the last
+                // known state rather than claiming discharge.
+                if let chargingNow { self.update(\.charging, chargingNow) }
                 self.lowBatteryNotifier.notify(deviceKey: self.deviceKey, deviceName: self.deviceName,
                                                percent: pct, charging: chargingNow)
                 self.update(\.timeEstimate, estimate)
@@ -315,6 +330,9 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             publish {
                 let wasConnected = self.connected
                 self.update(\.connected, false)
+                // An unreachable mouse isn't charging as far as we know — leaving this set
+                // strands the menu bar bolt on (dimmed) indefinitely after a disconnect.
+                self.update(\.charging, false)
                 self.update(\.lastError, err)
                 self.update(\.bluetoothMouseName, btName)
                 if gone {

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -222,6 +222,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     private func readBatterySync(immediateOffline: Bool = false) {
         let outcome: BatteryPollStateMachine.ReadOutcome
         var errText: String?
+        /// The charging flag exactly as the device reported it this tick. The verdict's
+        /// `isCharging` is the two-poll-*confirmed* one, which resets on any transient read
+        /// failure — so a docked mouse looks "not charging" on the first good poll after
+        /// one. That's harmless for the history reset the confirmation guards, but it would
+        /// fire a false "battery low, charge it soon" while the mouse sits on the charger.
+        var observedCharging = false
         do {
             let dev = try ensureDevice()
             if !ioHasBattery {
@@ -253,6 +259,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 // state machine's decision here.)
                 let charging = raw != 0
                     && ((try? dev.sendWithRetry(RazerCommands.getChargingStatus()))?.arguments[1] ?? 0) != 0
+                observedCharging = charging
                 outcome = .battery(raw: raw, charging: charging)
             }
         } catch {
@@ -276,13 +283,15 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             if recordSample { history.record(percent: pct, charging: isCharging) }
             let estimate = isCharging ? "Charging" : history.estimateString(currentPercent: pct, curveModel: curveModel)
             let snap = historySnapshot()
+            let chargingNow = observedCharging // immutable capture for the @Sendable publish block
             publishConnected {
                 // A real reading proves the mouse is responding again — a stale "couldn't
                 // apply" banner would now be lying (polls clear it within ~15s of a wake).
                 self.update(\.profileApplyFailed, false)
                 self.update(\.batteryPercent, pct)
                 self.update(\.charging, isCharging)
-                self.lowBatteryNotifier.notify(deviceName: self.deviceName, percent: pct, charging: isCharging)
+                self.lowBatteryNotifier.notify(deviceKey: self.deviceKey, deviceName: self.deviceName,
+                                               percent: pct, charging: chargingNow)
                 self.update(\.timeEstimate, estimate)
                 self.update(\.batterySamples, snap.samples)
                 self.update(\.previousCycleSamples, snap.previous)
@@ -717,7 +726,9 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             // session, same connection); without this, everything recorded so far would be
             // orphaned forever. Cross-session PID orphans are deliberately NOT migrated:
             // with two same-model units, they could belong to the other mouse.
-            if let old = historyKey, serial != nil, old == String(format: "%04x", pid) {
+            let isSameUnitKeyUpgrade = historyKey != nil && serial != nil
+                && historyKey == String(format: "%04x", pid)
+            if let old = historyKey, isSameUnitKeyUpgrade {
                 // Flush the live history's throttled tail first — the migration moves the
                 // file, and anything not yet written would silently vanish with it.
                 history.saveNow()
@@ -753,11 +764,13 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 self.profiles = loadedProfiles
                 self.activeProfileID = loadedActiveID
                 self.profilesLoadedForKey = key
-                // A new physical mouse — `notify()` only ever runs here on the main queue,
-                // so re-arm here too rather than from the io-queue caller above, or the two
-                // would race on `armed`. Otherwise this unit would silently inherit the
-                // previous mouse's "already notified" state and never alert on its own.
-                self.lowBatteryNotifier.deviceChanged()
+                // A genuinely different physical mouse — re-arm so it gets its own alert
+                // instead of inheriting the previous one's "already notified" state. Skipped
+                // for the same-unit PID→serial rename above, which would otherwise let one
+                // mouse alert twice in a single discharge. Done here on the main queue (not
+                // from the io-queue caller) because that's where `notify()` runs — the two
+                // must not race on the policy.
+                if !isSameUnitKeyUpgrade { self.lowBatteryNotifier.deviceChanged() }
             }
         }
         let name = d.productName

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -101,8 +101,13 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     private let pollWhenConnected: TimeInterval = 15
     private let pollWhenOffline: TimeInterval = 4
 
+    /// Re-read notification authorization (launch, and whenever the app is refocused) so a
+    /// low-battery alert isn't consumed while notifications are switched off.
+    func refreshNotificationAuthorization() { lowBatteryNotifier.refreshAuthorization() }
+
     func start() {
         wireHistory()
+        lowBatteryNotifier.refreshAuthorization()
         refreshAll()
         scheduleNextPoll(after: pollWhenOffline)
     }

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -91,6 +91,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
     private var curveModelKey: String?
     /// Suppresses connect/disconnect sounds until the first poll establishes a baseline.
     private var hasBaseline = false
+    private let lowBatteryNotifier = LowBatteryNotifier()
     /// io-queue only: the pure decision core of the poll loop — offline debounce, garbage
     /// rejection, charge confirmation. All the subtle logic lives (and is tested) there;
     /// this class just does the I/O and acts on the verdicts.
@@ -281,6 +282,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 self.update(\.profileApplyFailed, false)
                 self.update(\.batteryPercent, pct)
                 self.update(\.charging, isCharging)
+                self.lowBatteryNotifier.notify(deviceName: self.deviceName, percent: pct, charging: isCharging)
                 self.update(\.timeEstimate, estimate)
                 self.update(\.batterySamples, snap.samples)
                 self.update(\.previousCycleSamples, snap.previous)

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -753,6 +753,11 @@ final class MouseController: ObservableObject, @unchecked Sendable {
                 self.profiles = loadedProfiles
                 self.activeProfileID = loadedActiveID
                 self.profilesLoadedForKey = key
+                // A new physical mouse — `notify()` only ever runs here on the main queue,
+                // so re-arm here too rather than from the io-queue caller above, or the two
+                // would race on `armed`. Otherwise this unit would silently inherit the
+                // previous mouse's "already notified" state and never alert on its own.
+                self.lowBatteryNotifier.deviceChanged()
             }
         }
         let name = d.productName

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -482,7 +482,7 @@ struct PopoverView: View {
                     Text(verbatim: controller.batteryPercent.map { "\($0)" } ?? "—")
                         .font(.system(size: 34, weight: .semibold, design: .rounded))
                         .monospacedDigit()
-                        .foregroundStyle(controller.batteryPercent ?? 100 < 15 ? Color.batteryLow : .primary)
+                        .foregroundStyle(controller.batteryPercent ?? 100 < batteryLowThresholdPercent ? Color.batteryLow : .primary)
                         .contentTransition(.numericText())
                     Text("%").font(.system(size: 17, weight: .medium)).foregroundStyle(.secondary)
                 }

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -482,7 +482,7 @@ struct PopoverView: View {
                     Text(verbatim: controller.batteryPercent.map { "\($0)" } ?? "—")
                         .font(.system(size: 34, weight: .semibold, design: .rounded))
                         .monospacedDigit()
-                        .foregroundStyle(controller.batteryPercent ?? 100 < batteryLowThresholdPercent ? Color.batteryLow : .primary)
+                        .foregroundStyle(controller.batteryPercent ?? 100 < Battery.lowThresholdPercent ? Color.batteryLow : .primary)
                         .contentTransition(.numericText())
                     Text("%").font(.system(size: 17, weight: .medium)).foregroundStyle(.secondary)
                 }

--- a/Sources/MacRazer/UsageGraphView.swift
+++ b/Sources/MacRazer/UsageGraphView.swift
@@ -142,7 +142,7 @@ struct UsageGraphView: View {
     private static func levelBand(_ pct: Int) -> String {
         switch pct {
         case ..<Battery.lowThresholdPercent: return lowBand
-        case ..<40: return midBand
+        case ..<Battery.midThresholdPercent: return midBand
         default: return fullBand
         }
     }

--- a/Sources/MacRazer/UsageGraphView.swift
+++ b/Sources/MacRazer/UsageGraphView.swift
@@ -141,7 +141,7 @@ struct UsageGraphView: View {
     private static let previousColor = Color.gray.opacity(0.55)
     private static func levelBand(_ pct: Int) -> String {
         switch pct {
-        case ..<15: return lowBand
+        case ..<Battery.lowThresholdPercent: return lowBand
         case ..<40: return midBand
         default: return fullBand
         }

--- a/Sources/MacRazer/VersionCompare.swift
+++ b/Sources/MacRazer/VersionCompare.swift
@@ -7,16 +7,22 @@ import Foundation
 /// no pre-release suffixes to worry about for this project.
 enum VersionCompare {
     static func isNewer(_ remote: String, than local: String) -> Bool {
-        // `Int($0) ?? 0`, not compactMap: dropping an unparseable component would shift the
-        // later ones left, so "v0.1.0" parsed as [1, 0] and compared 1 > 0 against "0.2.0"
-        // — reporting a downgrade as an update. Unparseable components read as 0 in place.
-        let r = remote.split(separator: ".").map { Int($0) ?? 0 }
-        let l = local.split(separator: ".").map { Int($0) ?? 0 }
+        // Positional, never compacted: dropping an unparseable component shifts the later
+        // ones left, so "v0.1.0" parsed as [1, 0] and compared 1 > 0 against "0.2.0",
+        // reporting a downgrade as an update. Each component contributes its leading run of
+        // digits after any prefix junk ("v1" / "release-1" → 1, "0-beta" → 0), so a tag
+        // shape UpdateChecker doesn't strip can't silently reorder releases either.
+        let r = remote.split(separator: ".").map(Self.leadingNumber)
+        let l = local.split(separator: ".").map(Self.leadingNumber)
         for i in 0..<max(r.count, l.count) {
             let rv = i < r.count ? r[i] : 0
             let lv = i < l.count ? l[i] : 0
             if rv != lv { return rv > lv }
         }
         return false
+    }
+
+    private static func leadingNumber(_ component: Substring) -> Int {
+        Int(component.drop { !$0.isNumber }.prefix { $0.isNumber }) ?? 0
     }
 }

--- a/Sources/MacRazer/VersionCompare.swift
+++ b/Sources/MacRazer/VersionCompare.swift
@@ -7,8 +7,11 @@ import Foundation
 /// no pre-release suffixes to worry about for this project.
 enum VersionCompare {
     static func isNewer(_ remote: String, than local: String) -> Bool {
-        let r = remote.split(separator: ".").compactMap { Int($0) }
-        let l = local.split(separator: ".").compactMap { Int($0) }
+        // `Int($0) ?? 0`, not compactMap: dropping an unparseable component would shift the
+        // later ones left, so "v0.1.0" parsed as [1, 0] and compared 1 > 0 against "0.2.0"
+        // — reporting a downgrade as an update. Unparseable components read as 0 in place.
+        let r = remote.split(separator: ".").map { Int($0) ?? 0 }
+        let l = local.split(separator: ".").map { Int($0) ?? 0 }
         for i in 0..<max(r.count, l.count) {
             let rv = i < r.count ? r[i] : 0
             let lv = i < l.count ? l[i] : 0

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -33,6 +33,15 @@ func openDevice() -> HIDDevice? {
         return dev
     } catch {
         print("✗ \(error)")
+        // The GUI already turns this same failure into "Grant Input Monitoring…" guidance
+        // (PopoverView/PermissionsModel) — the CLI path was left printing a bare hex code.
+        if HIDDevice.errorLooksPermissionDenied(String(describing: error)) {
+            print("  → Grant Input Monitoring for this binary: System Settings › Privacy & Security ›")
+            print("    Input Monitoring, then run this command again. Note: an ad-hoc `swift build`")
+            print("    gets a new code signature on every rebuild, which resets the grant — run")
+            print("    ./Scripts/setup-signing.sh once for a stable identity, or keep re-running")
+            print("    `swift run`/this binary without rebuilding in between.")
+        }
         return nil
     }
 }

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -120,14 +120,22 @@ case "render-permissions":
 
 case "icon":
     // Render the menu bar mark to a PNG for visual inspection.
-    let path = args.dropFirst().first ?? "icon-preview.png"
-    // Optional trailing size, so the mark can be checked at real menu bar scale (~21pt @2x)
-    // rather than judged from a downsampled 256px render.
-    let size = args.dropFirst().compactMap { CGFloat(Int($0) ?? 0) }.first { $0 > 0 } ?? 256
+    // Flags and the optional size are bare words, so they must be excluded from the
+    // positional path — otherwise `icon charging` writes a file literally named "charging".
+    let iconFlags: Set<String> = ["charging", "nologo"]
+    let iconArgs = args.dropFirst()
+    let path = iconArgs.first { !iconFlags.contains($0) && Int($0) == nil } ?? "icon-preview.png"
+    // Optional size, so the mark can be checked at real menu bar scale (~21pt @2x) rather
+    // than judged from a downsampled 256px render. Bounded: an unbounded value makes the
+    // bitmap allocation fail and the write silently do nothing.
+    let size = iconArgs.compactMap { Int($0) }.first { $0 > 0 }.map { CGFloat(min($0, 2048)) } ?? 256
     // `nologo` matches the menu bar's own call (razerCutout: false) so what's previewed is
     // what ships there.
-    MenuBarIcon.writePreview(to: path, size: size, razerCutout: !args.contains("nologo"),
-                             charging: args.contains("charging"))
+    guard MenuBarIcon.writePreview(to: path, size: size, razerCutout: !iconArgs.contains("nologo"),
+                                   charging: iconArgs.contains("charging")) else {
+        print("Render failed")
+        exit(1)
+    }
     print("Wrote \(path)")
 
 case "icon-models":

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -26,6 +26,23 @@ if args.isEmpty {
 
 let command = args.first!
 
+/// Turn a permission-denied failure into the fix, instead of leaving a bare hex code on
+/// screen. The GUI already does this (PopoverView / PermissionsModel); every CLI catch
+/// routes through here so it does too. Returns whether the error was a permission problem,
+/// so callers can suppress advice that would then be misleading.
+@discardableResult
+func printPermissionHintIfDenied(_ error: Error) -> Bool {
+    guard HIDDevice.errorLooksPermissionDenied(String(describing: error)) else { return false }
+    print("  → macOS is refusing HID access (Input Monitoring).")
+    print("    Running via `swift run MacRazer …`? The grant belongs to the terminal that")
+    print("    launched it, not to the SwiftPM binary — grant Terminal (or iTerm/your IDE) in")
+    print("    System Settings › Privacy & Security › Input Monitoring, then start a new")
+    print("    terminal session and retry.")
+    print("    Running MacRazer.app? Grant MacRazer itself there, then relaunch it — macOS")
+    print("    only applies the grant to a freshly-launched app.")
+    return true
+}
+
 func openDevice() -> HIDDevice? {
     do {
         let dev = try HIDDevice.open(vendorId: Razer.vendorId)
@@ -33,15 +50,7 @@ func openDevice() -> HIDDevice? {
         return dev
     } catch {
         print("✗ \(error)")
-        // The GUI already turns this same failure into "Grant Input Monitoring…" guidance
-        // (PopoverView/PermissionsModel) — the CLI path was left printing a bare hex code.
-        if HIDDevice.errorLooksPermissionDenied(String(describing: error)) {
-            print("  → Grant Input Monitoring for this binary: System Settings › Privacy & Security ›")
-            print("    Input Monitoring, then run this command again. Note: an ad-hoc `swift build`")
-            print("    gets a new code signature on every rebuild, which resets the grant — run")
-            print("    ./Scripts/setup-signing.sh once for a stable identity, or keep re-running")
-            print("    `swift run`/this binary without rebuilding in between.")
-        }
+        printPermissionHintIfDenied(error)
         return nil
     }
 }
@@ -172,8 +181,12 @@ case "battery":
         print("Full response args[0..8]: \(resp.arguments[0..<9].map { String(format: "%02x", $0) }.joined(separator: " "))")
     } catch {
         print("Battery read failed: \(error)")
-        print("(This is the documented wireless-dongle timeout. Try: re-seat the dongle, ")
-        print(" move the mouse to wake it, or test over wired USB-C to compare.)")
+        // Only blame the dongle when it isn't a permission problem — sending someone to
+        // re-seat hardware over a TCC denial wastes their time.
+        if !printPermissionHintIfDenied(error) {
+            print("(This is the documented wireless-dongle timeout. Try: re-seat the dongle, ")
+            print(" move the mouse to wake it, or test over wired USB-C to compare.)")
+        }
         exit(2)
     }
 
@@ -203,6 +216,7 @@ case "dpi":
         }
     } catch {
         print("DPI command failed: \(error)")
+        printPermissionHintIfDenied(error)
         exit(2)
     }
 
@@ -234,6 +248,7 @@ case "stages":
         }
     } catch {
         print("Stages command failed: \(error)")
+        printPermissionHintIfDenied(error)
         exit(2)
     }
 
@@ -259,6 +274,7 @@ case "poll":
         }
     } catch {
         print("Poll-rate command failed: \(error)")
+        printPermissionHintIfDenied(error)
         exit(2)
     }
 
@@ -291,7 +307,9 @@ case "brightness":
             print("  read-back: \(dump(back)) → \(RazerCommands.brightnessPercent(fromRaw: back.arguments[2]))%")
         }
     } catch {
-        print("Brightness probe failed: \(error)"); exit(2)
+        print("Brightness probe failed: \(error)")
+        printPermissionHintIfDenied(error)
+        exit(2)
     }
 
 case "rgb":
@@ -328,6 +346,7 @@ case "rgb":
         print("  status = 0x\(String(resp.status, radix: 16)) \(ok ? "✓" : "⚠︎")")
     } catch {
         print("RGB command failed: \(error)")
+        printPermissionHintIfDenied(error)
         exit(2)
     }
 

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -121,7 +121,13 @@ case "render-permissions":
 case "icon":
     // Render the menu bar mark to a PNG for visual inspection.
     let path = args.dropFirst().first ?? "icon-preview.png"
-    MenuBarIcon.writePreview(to: path, size: 256)
+    // Optional trailing size, so the mark can be checked at real menu bar scale (~21pt @2x)
+    // rather than judged from a downsampled 256px render.
+    let size = args.dropFirst().compactMap { CGFloat(Int($0) ?? 0) }.first { $0 > 0 } ?? 256
+    // `nologo` matches the menu bar's own call (razerCutout: false) so what's previewed is
+    // what ships there.
+    MenuBarIcon.writePreview(to: path, size: size, razerCutout: !args.contains("nologo"),
+                             charging: args.contains("charging"))
     print("Wrote \(path)")
 
 case "icon-models":

--- a/Tests/MacRazerTests/LowBatteryAlertPolicyTests.swift
+++ b/Tests/MacRazerTests/LowBatteryAlertPolicyTests.swift
@@ -81,8 +81,24 @@ final class LowBatteryAlertPolicyTests: XCTestCase {
         }
         XCTAssertFalse(isCharging, "the confirmation resets after a failure — this is the trap")
 
+        // The assertion that actually pins the wiring: feeding the DEBOUNCED flag fires a
+        // false alert for a mouse that is plainly on the charger...
+        var wrong = LowBatteryAlertPolicy()
+        XCTAssertTrue(wrong.shouldAlert(percent: pct, charging: isCharging),
+                      "regression guard: the debounced flag is what would misfire")
+        // ...while the observed flag — what MouseController actually passes — suppresses it.
+        var right = LowBatteryAlertPolicy()
+        XCTAssertFalse(right.shouldAlert(percent: pct, charging: true))
+    }
+
+    func testUnknownChargingNeitherAlertsNorRearms() {
         var p = LowBatteryAlertPolicy()
-        XCTAssertFalse(p.shouldAlert(percent: pct, charging: true),
-                       "the observed flag must suppress the alert even when the debounced one says false")
+        // The charging read failed: "don't know" must not be taken as "on battery".
+        XCTAssertFalse(p.shouldAlert(percent: 10, charging: nil))
+        // Still armed — a later confirmed-discharging read alerts normally.
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+        // And an unknown read afterwards doesn't re-arm it either.
+        XCTAssertFalse(p.shouldAlert(percent: 10, charging: nil))
+        XCTAssertFalse(p.shouldAlert(percent: 10, charging: false))
     }
 }

--- a/Tests/MacRazerTests/LowBatteryAlertPolicyTests.swift
+++ b/Tests/MacRazerTests/LowBatteryAlertPolicyTests.swift
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+final class LowBatteryAlertPolicyTests: XCTestCase {
+    private let low = Battery.lowThresholdPercent      // 15
+    private let rearm = Battery.lowRearmPercent        // 20
+
+    func testAlertsOnceWhenDroppingBelowThreshold() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertFalse(p.shouldAlert(percent: low, charging: false), "at the threshold is not below it")
+        XCTAssertTrue(p.shouldAlert(percent: low - 1, charging: false))
+    }
+
+    func testDoesNotRepeatWhileStayingLow() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertTrue(p.shouldAlert(percent: 14, charging: false))
+        // The poll loop keeps feeding readings every ~15s all the way down.
+        for pct in stride(from: 13, through: 0, by: -1) {
+            XCTAssertFalse(p.shouldAlert(percent: pct, charging: false), "re-alerted at \(pct)%")
+        }
+    }
+
+    func testChargingSuppressesAndRearms() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+        XCTAssertFalse(p.shouldAlert(percent: 10, charging: true), "never alert while charging")
+        // Docked and re-armed; unplugged again while still low → a new episode alerts.
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+    }
+
+    func testRearmNeedsHysteresisNotJustCrossingBackOverTheThreshold() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertTrue(p.shouldAlert(percent: 14, charging: false))
+        // A garbage-but-accepted reading between the two thresholds must NOT re-arm, or the
+        // next genuine low reading fires a duplicate alert for the same discharge.
+        XCTAssertFalse(p.shouldAlert(percent: low, charging: false))
+        XCTAssertFalse(p.shouldAlert(percent: rearm - 1, charging: false))
+        XCTAssertFalse(p.shouldAlert(percent: 14, charging: false), "duplicate after a mid-band blip")
+        // A real recharge clears the hysteresis band and re-arms.
+        XCTAssertFalse(p.shouldAlert(percent: rearm, charging: false))
+        XCTAssertTrue(p.shouldAlert(percent: 14, charging: false))
+    }
+
+    func testDeviceChangeRearmsForTheNewMouse() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+        XCTAssertFalse(p.shouldAlert(percent: 9, charging: false))
+        // A second, already-low mouse has never been alerted on.
+        p.deviceChanged()
+        XCTAssertTrue(p.shouldAlert(percent: 9, charging: false))
+    }
+
+    func testFailedDeliveryRearmsSoTheEpisodeIsNotSkipped() {
+        var p = LowBatteryAlertPolicy()
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+        p.rearmAfterFailedDelivery() // notifications denied — nothing was shown
+        XCTAssertTrue(p.shouldAlert(percent: 10, charging: false))
+    }
+
+    /// The regression this policy exists for: `BatteryPollStateMachine` clears its
+    /// two-poll charge confirmation on any transient read failure, so a docked mouse
+    /// reports `isCharging == false` on the next good poll. Feeding that debounced flag
+    /// here would fire "charge it soon" while the mouse sits on the charger.
+    func testObservedChargingFlagIsWhatSuppressesTheAlert() {
+        var machine = BatteryPollStateMachine()
+        func feed(raw: UInt8, charging: Bool) -> BatteryPollStateMachine.Verdict {
+            machine.handle(.battery(raw: raw, charging: charging), immediateOffline: false)
+        }
+        let lowRaw = UInt8(10 * 255 / 100) // ~10%
+        _ = feed(raw: lowRaw, charging: true)
+        _ = feed(raw: lowRaw, charging: true) // confirmed charging by now
+        _ = machine.handle(.failure(deviceGone: false), immediateOffline: false)
+        _ = machine.handle(.failure(deviceGone: false), immediateOffline: false)
+        let verdict = feed(raw: lowRaw, charging: true)
+
+        guard case .reading(let pct, let isCharging, _) = verdict else {
+            return XCTFail("expected a reading, got \(verdict)")
+        }
+        XCTAssertFalse(isCharging, "the confirmation resets after a failure — this is the trap")
+
+        var p = LowBatteryAlertPolicy()
+        XCTAssertFalse(p.shouldAlert(percent: pct, charging: true),
+                       "the observed flag must suppress the alert even when the debounced one says false")
+    }
+}

--- a/Tests/MacRazerTests/RazerProtocolTests.swift
+++ b/Tests/MacRazerTests/RazerProtocolTests.swift
@@ -169,11 +169,15 @@ final class VersionCompareTests: XCTestCase {
         XCTAssertFalse(VersionCompare.isNewer("0.1", than: "0.1.0")) // trailing zero equal
     }
 
-    func testNonNumericSuffixIsDroppedNotFatal() {
-        // "0.2.0-beta" loses its non-numeric last component rather than crashing — the
-        // comparison then falls through to treating that component as 0.
+    func testUnparseableComponentsReadAsZeroInPlace() {
+        // Regression: compactMap dropped a bad component and shifted the rest left, so
+        // "v0.1.0" parsed as [1, 0] and compared 1 > 0 — calling a downgrade an update.
+        // UpdateChecker strips a bare leading "v", but any other tag shape reaches here.
+        XCTAssertFalse(VersionCompare.isNewer("v0.1.0", than: "0.2.0"))
+        XCTAssertFalse(VersionCompare.isNewer("release-0.1.0", than: "0.2.0"))
+        // The component reads as 0 where it stands, so a pre-release sorts as its base.
         XCTAssertFalse(VersionCompare.isNewer("0.2.0-beta", than: "0.2.0"))
-        // An earlier, purely-numeric component still decides the comparison correctly.
+        // Earlier numeric components still decide the comparison.
         XCTAssertTrue(VersionCompare.isNewer("0.3.0-beta", than: "0.2.9"))
     }
 }

--- a/Tests/MacRazerTests/RazerProtocolTests.swift
+++ b/Tests/MacRazerTests/RazerProtocolTests.swift
@@ -168,4 +168,12 @@ final class VersionCompareTests: XCTestCase {
         XCTAssertFalse(VersionCompare.isNewer("0.1.5", than: "0.1.5"))
         XCTAssertFalse(VersionCompare.isNewer("0.1", than: "0.1.0")) // trailing zero equal
     }
+
+    func testNonNumericSuffixIsDroppedNotFatal() {
+        // "0.2.0-beta" loses its non-numeric last component rather than crashing — the
+        // comparison then falls through to treating that component as 0.
+        XCTAssertFalse(VersionCompare.isNewer("0.2.0-beta", than: "0.2.0"))
+        // An earlier, purely-numeric component still decides the comparison correctly.
+        XCTAssertTrue(VersionCompare.isNewer("0.3.0-beta", than: "0.2.9"))
+    }
 }

--- a/Tests/MacRazerTests/RazerProtocolTests.swift
+++ b/Tests/MacRazerTests/RazerProtocolTests.swift
@@ -169,15 +169,18 @@ final class VersionCompareTests: XCTestCase {
         XCTAssertFalse(VersionCompare.isNewer("0.1", than: "0.1.0")) // trailing zero equal
     }
 
-    func testUnparseableComponentsReadAsZeroInPlace() {
-        // Regression: compactMap dropped a bad component and shifted the rest left, so
+    func testComponentsWithPrefixJunkStillCompareByTheirNumber() {
+        // Regression 1: compactMap dropped a bad component and shifted the rest left, so
         // "v0.1.0" parsed as [1, 0] and compared 1 > 0 — calling a downgrade an update.
-        // UpdateChecker strips a bare leading "v", but any other tag shape reaches here.
         XCTAssertFalse(VersionCompare.isNewer("v0.1.0", than: "0.2.0"))
         XCTAssertFalse(VersionCompare.isNewer("release-0.1.0", than: "0.2.0"))
-        // The component reads as 0 where it stands, so a pre-release sorts as its base.
+        // Regression 2: reading a junk component as a flat 0 fixed the shift but then
+        // buried real updates whose leading component wasn't bare digits.
+        XCTAssertTrue(VersionCompare.isNewer("V1.2.3", than: "1.0.0"))
+        XCTAssertTrue(VersionCompare.isNewer("MacRazer-1.2.3", than: "1.0.0"))
+        XCTAssertFalse(VersionCompare.isNewer("V1.0.0", than: "1.0.0"))
+        // A pre-release suffix sorts as its base version.
         XCTAssertFalse(VersionCompare.isNewer("0.2.0-beta", than: "0.2.0"))
-        // Earlier numeric components still decide the comparison.
         XCTAssertTrue(VersionCompare.isNewer("0.3.0-beta", than: "0.2.9"))
     }
 }


### PR DESCRIPTION
## Summary
- CLI diagnostics (`battery`/`dpi`/`poll`/`rgb`/`brightness`) now print Input Monitoring guidance on a permission-denied `IOHIDDeviceOpen` failure, mirroring what the GUI already shows. Previously `openDevice()` printed a bare `IOHIDDeviceOpen failed: 0xe00002e2` with no hint.
- Adds a system notification when the battery drops below 15% (the same threshold the battery card already colors red). Re-arms on charging or recovering back to 15%+, so it can't repeat every poll.
- Adds a `VersionCompare` test for a non-numeric trailing component (e.g. `"0.2.0-beta"`), pinning down behavior of the string that drives the update-available banner.

## Note on #3
This PR does **not** close #3, despite the same error code appearing in both. The reporter ran `swift run` with no subcommand, which launches the **GUI** menu bar app — their `[MacRazer] battery read failed (1): …` line is emitted by `MouseController.readBatterySync`, not by the CLI's `openDevice()` that this PR touches. The GUI path already has permission guidance (permissions window at launch, "Grant Input Monitoring…" in the popover).

#3 still needs, separately:
- confirmation of whether the reporter saw/actioned the existing GUI permission prompt, and whether the ad-hoc-rebuild signature reset is what keeps resetting the grant under `swift run`;
- a `RazerDevices` registry entry for the Pro Click V2 Vertical (their control interface reports PID `0x00c7`; OpenRazer lists the device as `1532:00c8`) — which per the README needs on-hardware verification, so it can't be added blind.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 70/70 pass
- [x] Ran the built `.app` against real hardware (Cobra HyperSpeed over the wireless dongle) — menu bar item live, battery % correct
- [x] Notification path verified end-to-end with a temporary raised threshold (reverted before commit), since the test mouse sits well above 15%