### PR TITLE
Add Razer Basilisk V3 X HyperSpeed (0x00B9) and Basilisk X HyperSpeed (0x0083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Added
+- **Razer Basilisk V3 X HyperSpeed support** (PID `0x00B9`), verified on hardware over the
+ 2.4 GHz dongle: battery, DPI, the onboard DPI stage table, polling rate, lighting effects
+ and brightness all read and write. Detection and naming already worked for any Razer mouse;
+ what's new is that this model's controls are confirmed rather than assumed. It takes the
+ Cobra family's `0x1f` transaction id for every command class, including the DPI-stages pair
+ the Basilisk V3 needs an override for. Being AA-cell powered it never reports charging, and
+ it stays on the generic linear estimate rather than the Cobra's learned discharge curve,
+ whose Li-ion behavior doesn't apply.
+- **Razer Basilisk X HyperSpeed** (PID `0x0083`), ported from the OpenRazer tables — no
+ lighting at all, a 16000 DPI ceiling, and `0xFF` transaction ids rather than the Cobra
+ family's `0x1f`. Nobody has run it against hardware yet, so it stays marked unverified: the
+ app will attempt its controls without claiming they work.
+
+### Fixed
+- **The brightness slider now works on mice whose only lit zone is the scroll wheel.** The LED
+ group for brightness was hardcoded to `LOGO_LED`, which the Basilisk V3 X HyperSpeed answers
+ with FAILURE (`0x03`), so dragging the slider silently did nothing on it. Effects and
+ brightness live on different LED groups, and which group answers varies per model, so the id
+ is now a per-model registry field defaulting to the Cobra family's `LOGO_LED` — an unknown
+ mouse behaves exactly as before.
+- **The `brightness` CLI probe no longer stops at the first LED group that refuses.** It exists
+ to discover which group a new model answers on, but a `LOGO_LED` refusal threw before the
+ sweep started — precisely the case it was written for. It now reports LOGO, SCROLL, ZERO and
+ BACKLIGHT individually, so a new model's brightness LED can be found in one run.
+
 ## [0.3.0] — 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,12 +53,32 @@ the mouse connects, disconnects, or sleeps.
 |---|---|
 | Razer Cobra HyperSpeed (wired + wireless) | Tested, works best |
 | Razer Atheris | Tested, works best |
+| Razer Basilisk V3 X HyperSpeed | Tested, works best |
 | Razer Basilisk V3 | In the registry; user-reported working |
+| Razer Basilisk X HyperSpeed | In the registry; not yet hardware-verified |
 | Razer Cobra, Cobra Pro (wired + wireless) | Same protocol, not yet hardware-verified here |
 | Any other Razer mouse | Detected and named; should work, but untested |
 
 Adding a model is a small change to a registry plus on-hardware verification. See
 [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Buttons MacRazer cannot see
+
+Remapping works by watching macOS mouse events, so it can only reach buttons the mouse
+actually reports to the Mac. Some buttons are handled *inside* the mouse and never send
+anything — no app can detect those, MacRazer included.
+
+The clearest example is the **Basilisk's multi-function trigger** (the third side button),
+which ships assigned to **Razer Hypershift**. Hypershift is a modifier: held down, it
+switches every other button to a second onboard layer. The firmware resolves that layer
+itself, so pressing the trigger alone puts no report on the wire at all — verified by
+watching every HID interface the mouse exposes while it was pressed.
+
+To make it remappable, reassign it from Hypershift to a normal key or mouse button in
+Razer Synapse (Windows only — Razer dropped macOS support). The assignment is stored in the
+mouse's onboard memory, so it persists on the Mac afterwards and MacRazer will then see the
+button like any other. MacRazer deliberately does not reprogram onboard assignments itself;
+that would mean reverse-engineering Synapse, which Razer's EULA forbids.
 
 ### Known limitation: two identical mice without a hardware serial
 

--- a/Sources/MacRazer/HIDDevice.swift
+++ b/Sources/MacRazer/HIDDevice.swift
@@ -29,7 +29,7 @@ final class HIDDevice {
         var description: String {
             func hex(_ r: IOReturn) -> String { String(format: "0x%08x", UInt32(bitPattern: r)) }
             switch self {
-            case .notFound: return "Razer Cobra HyperSpeed not found on USB (is the 2.4GHz dongle plugged in?)"
+            case .notFound: return "No Razer mouse found on USB (is the cable or 2.4GHz dongle plugged in?)"
             case .openFailed(let r): return "IOHIDDeviceOpen failed: \(hex(r))"
             case .setReportFailed(let r): return "SetReport failed: \(hex(r))"
             case .getReportFailed(let r): return "GetReport failed: \(hex(r))"

--- a/Sources/MacRazer/MouseController.swift
+++ b/Sources/MacRazer/MouseController.swift
@@ -396,7 +396,7 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         }
         let d = read(RazerCommands.getDPI()) { Int(RazerCommands.parseDPI($0).x) }
         let p = read(RazerCommands.getPollingRate()) { RazerCommands.parsePollingRate($0) }
-        let b = read(RazerCommands.getBrightness()) { RazerCommands.brightnessPercent(fromRaw: $0.arguments[2]) }
+        let b = read(RazerCommands.getBrightness(led: RazerDevices.brightnessLed(pid: dev.productID))) { RazerCommands.brightnessPercent(fromRaw: $0.arguments[2]) }
         let stages = read(RazerCommands.getDPIStages()) { RazerCommands.parseDPIStages($0) } ?? []
         publish {
             if let d { self.update(\.dpi, d) }
@@ -453,7 +453,12 @@ final class MouseController: ObservableObject, @unchecked Sendable {
         let pct = max(0, min(percent, 100))
         io.async { [weak self] in
             guard let self else { return }
-            let ok = (try? self.ensureDevice().sendWithRetry(RazerCommands.setBrightness(RazerCommands.brightnessRaw(fromPercent: pct)))) != nil
+            let ok = (try? {
+                let dev = try self.ensureDevice()
+                return try dev.sendWithRetry(RazerCommands.setBrightness(
+                    RazerCommands.brightnessRaw(fromPercent: pct),
+                    led: RazerDevices.brightnessLed(pid: dev.productID)))
+            }()) != nil
             self.publish {
                 guard ok else { self.lastWriteFailure = Date(); return }
                 self.brightness = pct; self.clearActiveProfileIfNeeded()
@@ -587,7 +592,9 @@ final class MouseController: ObservableObject, @unchecked Sendable {
             // (correctly) refuses them, and that must not block its profiles from applying.
             let hasLighting = RazerDevices.hasLighting(pid: dev.productID)
             let brightOK = !hasLighting
-                || (try? dev.sendWithRetry(RazerCommands.setBrightness(RazerCommands.brightnessRaw(fromPercent: brightnessPct)))) != nil
+                || (try? dev.sendWithRetry(RazerCommands.setBrightness(
+                        RazerCommands.brightnessRaw(fromPercent: brightnessPct),
+                        led: RazerDevices.brightnessLed(pid: dev.productID)))) != nil
             let lightOK = !hasLighting || (try? dev.sendWithRetry(lighting)) != nil
             let allOK = stagesOK && dpiOK && pollOK && brightOK && lightOK
             let anyOK = dpiOK || pollOK || (hasLighting && (brightOK || lightOK))

--- a/Sources/MacRazer/RazerCommands.swift
+++ b/Sources/MacRazer/RazerCommands.swift
@@ -27,6 +27,7 @@ enum Razer {
     // LED ids (razercommon.h)
     static let backlightLed: UInt8 = 0x05
     static let logoLed: UInt8 = 0x04
+    static let scrollLed: UInt8 = 0x01
 }
 
 /// RGB triple.
@@ -236,8 +237,11 @@ enum RazerCommands {
 
     /// razer_chroma_extended_matrix_brightness(VARSTORE, led, brightness)
     ///   get_razer_report(0x0F, 0x04, 0x03); args: store, led, brightness (0–255)
-    /// NOTE: on the Cobra HyperSpeed brightness only works on the LOGO LED (0x04); ZERO_LED
-    /// and BACKLIGHT return status 0x03 (failure). Verified on hardware.
+    /// NOTE: brightness lives on a different LED group than the effect commands, and which
+    /// group varies per model — the Cobra HyperSpeed answers only on LOGO_LED (0x04), the
+    /// Basilisk V3 X HyperSpeed only on SCROLL_LED (0x01), and every other group returns
+    /// status 0x03 (failure). Callers pass the model's id from `RazerDevices.brightnessLed`;
+    /// the LOGO_LED default here is the Cobra-family value. Both verified on hardware.
     static func setBrightness(_ value: UInt8, led: UInt8 = Razer.logoLed) -> RazerReport {
         var r = RazerReport(commandClass: 0x0F, commandId: 0x04, dataSize: 0x03)
         r.arguments[0] = Razer.varstore

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -50,6 +50,13 @@ struct RazerDeviceInfo {
     /// DPI-stages pair (0x04/0x06 and 0x04/0x86), which it shares with the plain Cobra's
     /// 0xFF group.
     var transactionOverrides: [UInt16: UInt8] = [:]
+    /// Which LED group answers the extended-matrix *brightness* commands (class 0x0F,
+    /// 0x04/0x84). Not the same id the effect commands take: the Cobra family drives
+    /// effects as one group via ZERO_LED but only answers brightness on LOGO_LED, and the
+    /// Basilisk V3 X HyperSpeed — whose only lit zone is the scroll wheel — answers on
+    /// SCROLL_LED and returns FAILURE (0x03) for LOGO, ZERO and BACKLIGHT alike
+    /// (hardware-verified via the `brightness` probe).
+    var brightnessLed: UInt8 = Razer.logoLed
     let connection: RazerConnection
     let silhouette: RazerMouseSilhouette
     /// Model key for the learned per-percent discharge curve (see `DischargeCurveModel`), or nil
@@ -78,6 +85,14 @@ enum RazerDevices {
         // OpenRazer uses 0xFF for the Atheris, but 0x1f is what this app was hardware-tested
         // with (README) — verified behavior wins over the reference here.
         .init(pid: 0x0062, name: "Razer Atheris", fullySupported: true, hasBattery: true, hasLighting: false, maxDPI: 7200, transactionId: 0x1f, matrixTransactionId: 0x1f, connection: .wirelessDongle, silhouette: .atheris, dischargeCurveModelKey: nil),
+        // Basilisk V3 X HyperSpeed: AA-cell wireless (2.4 GHz dongle or Bluetooth — no
+        // charging, so `is_charging` is always false). Scroll-wheel-only lighting. 0x1f
+        // everywhere per razermouse_driver.c; hardware-verified with this app.
+        .init(pid: 0x00B9, name: "Razer Basilisk V3 X HyperSpeed", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 18000, transactionId: 0x1f, matrixTransactionId: 0x1f, brightnessLed: Razer.scrollLed, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        // Basilisk X HyperSpeed: the older AA-cell sibling — no lighting at all, and
+        // razermouse_driver.c gives it 0xFF for every command it supports. Not verified
+        // on hardware by us.
+        .init(pid: 0x0083, name: "Razer Basilisk X HyperSpeed", fullySupported: false, hasBattery: true, hasLighting: false, maxDPI: 16000, transactionId: 0xff, matrixTransactionId: 0xff, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Basilisk V3 (user-reported working): wired-only, 11-zone lighting. Per
         // razermouse_driver.c it takes 0x1f everywhere except the DPI-stages pair, which it
         // shares with the plain Cobra's 0xFF group. Not yet re-verified on hardware by us.
@@ -108,4 +123,9 @@ enum RazerDevices {
     }
     static func silhouette(pid: Int?) -> RazerMouseSilhouette { pid.flatMap { info(pid: $0)?.silhouette } ?? .cobra }
     static func dischargeCurveModelKey(pid: Int) -> String? { info(pid: pid)?.dischargeCurveModelKey }
+    /// LED group for brightness get/set. Unknown models fall back to LOGO_LED, the id the
+    /// Cobra family answers on.
+    static func brightnessLed(pid: Int?) -> UInt8 {
+        pid.flatMap { info(pid: $0)?.brightnessLed } ?? Razer.logoLed
+    }
 }

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -87,7 +87,7 @@ case "info":
         print("No Razer devices found (VID 0x1532).")
         exit(1)
     }
-    print("Found \(devices.count) HID interface(s) for the Cobra HyperSpeed:")
+    print("Found \(devices.count) HID interface(s) for VID 0x1532:")
     for (i, dev) in devices.enumerated() {
         print("  [\(i)] \(HIDDevice.describe(dev))")
     }
@@ -363,25 +363,27 @@ case "brightness":
         "status=0x\(String(r.status, radix: 16)) args[0..5]=" + r.arguments[0..<6].map { String(format: "%02x", $0) }.joined(separator: " ")
     }
     do {
-        let r = try dev.sendWithRetry(RazerCommands.getBrightness()) // defaults to LOGO_LED
-        print("GET brightness (led LOGO=0x04, the app's default): \(dump(r)) → \(RazerCommands.brightnessPercent(fromRaw: r.arguments[2]))%")
-        // Also probe the other LED groups. Per-LED refusals are expected (the HyperSpeed
-        // answers 0x03 for all but LOGO) — report and keep going; this sweep exists
-        // precisely to discover which LEDs answer on a given model.
-        for (name, led) in [("ZERO", UInt8(0x00)), ("BACKLIGHT", UInt8(0x05))] {
+        // Probe every LED group, LOGO first. A refusal on any one of them — including
+        // LOGO — is expected on some models (the Basilisk V3 X HyperSpeed lights only its
+        // scroll wheel and answers 0x03 for LOGO), so this must not abort the sweep: the
+        // whole point is to discover which LEDs answer on a model we don't know yet.
+        for (name, led) in [("LOGO", Razer.logoLed), ("SCROLL", Razer.scrollLed),
+                            ("ZERO", UInt8(0x00)), ("BACKLIGHT", Razer.backlightLed)] {
             do {
                 let rr = try dev.sendWithRetry(RazerCommands.getBrightness(led: led))
-                print("GET brightness (led \(name)=0x\(String(format: "%02x", led))): \(dump(rr))")
+                print("GET brightness (led \(name)=0x\(String(format: "%02x", led))): \(dump(rr))"
+                      + " → \(RazerCommands.brightnessPercent(fromRaw: rr.arguments[2]))%")
             } catch {
                 print("GET brightness (led \(name)=0x\(String(format: "%02x", led))): refused — \(error)")
             }
         }
         if let arg = args.dropFirst().first, let pct = Int(arg) {
+            let led = RazerDevices.brightnessLed(pid: dev.productID)
             let raw = RazerCommands.brightnessRaw(fromPercent: pct)
-            print("SET brightness \(pct)% (raw \(raw)) on LOGO_LED …")
-            let sr = try dev.sendWithRetry(RazerCommands.setBrightness(raw))
+            print("SET brightness \(pct)% (raw \(raw)) on led 0x\(String(format: "%02x", led)) …")
+            let sr = try dev.sendWithRetry(RazerCommands.setBrightness(raw, led: led))
             print("  set: \(dump(sr))")
-            let back = try dev.sendWithRetry(RazerCommands.getBrightness())
+            let back = try dev.sendWithRetry(RazerCommands.getBrightness(led: led))
             print("  read-back: \(dump(back)) → \(RazerCommands.brightnessPercent(fromRaw: back.arguments[2]))%")
         }
     } catch {

--- a/Tests/MacRazerTests/RazerDevicesTests.swift
+++ b/Tests/MacRazerTests/RazerDevicesTests.swift
@@ -34,6 +34,44 @@ final class RazerDevicesTests: XCTestCase {
         XCTAssertEqual(txn(0x0099, 0x04, 0x06), 0xff) // set DPI stages
         XCTAssertEqual(txn(0x0099, 0x04, 0x86), 0xff) // get DPI stages
         XCTAssertEqual(txn(0x0099, matrix, 0x02), 0x1f) // lighting
+        // Basilisk V3 X HyperSpeed: 0x1f for every class (hardware-verified — battery,
+        // DPI, polling and scroll brightness all answer). Its older sibling, the plain
+        // Basilisk X HyperSpeed, takes 0xFF everywhere per razermouse_driver.c.
+        for cls in [misc, matrix] {
+            XCTAssertEqual(txn(0x00B9, cls), 0x1f)
+            XCTAssertEqual(txn(0x0083, cls), 0xff)
+        }
+    }
+
+    /// The brightness LED id is not the same across models and a wrong one is not a silent
+    /// no-op — the device answers FAILURE (0x03) and the brightness slider stops working.
+    func testBrightnessLedPerModel() {
+        // Cobra family: only LOGO_LED answers (ZERO/BACKLIGHT refuse).
+        XCTAssertEqual(RazerDevices.brightnessLed(pid: 0x00DB), Razer.logoLed)
+        XCTAssertEqual(RazerDevices.brightnessLed(pid: 0x00A3), Razer.logoLed)
+        // Basilisk V3 X HyperSpeed lights only its scroll wheel — hardware-verified that
+        // SCROLL_LED answers and LOGO, ZERO and BACKLIGHT all return 0x03.
+        XCTAssertEqual(RazerDevices.brightnessLed(pid: 0x00B9), Razer.scrollLed)
+        // Unknown models keep the Cobra-family default.
+        XCTAssertEqual(RazerDevices.brightnessLed(pid: 0x9999), Razer.logoLed)
+        XCTAssertEqual(RazerDevices.brightnessLed(pid: nil), Razer.logoLed)
+    }
+
+    /// The two Basilisk HyperSpeed models differ in exactly the ways that matter for the
+    /// UI: the V3 X has scroll lighting and a higher ceiling, the plain X has no lighting.
+    func testBasiliskHyperSpeedCapabilities() {
+        XCTAssertTrue(RazerDevices.hasBattery(pid: 0x00B9))
+        XCTAssertTrue(RazerDevices.hasLighting(pid: 0x00B9))
+        XCTAssertEqual(RazerDevices.maxDPI(pid: 0x00B9), 18000)
+        XCTAssertEqual(RazerDevices.connection(pid: 0x00B9), .wirelessDongle)
+
+        XCTAssertTrue(RazerDevices.hasBattery(pid: 0x0083))
+        XCTAssertFalse(RazerDevices.hasLighting(pid: 0x0083), "the plain X HyperSpeed has no RGB at all")
+        XCTAssertEqual(RazerDevices.maxDPI(pid: 0x0083), 16000)
+
+        // Both are AA-cell mice, so neither shares the Cobra's learned discharge curve.
+        XCTAssertNil(RazerDevices.dischargeCurveModelKey(pid: 0x00B9))
+        XCTAssertNil(RazerDevices.dischargeCurveModelKey(pid: 0x0083))
     }
 
     func testConnectionKind() {

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -3,8 +3,9 @@
 A native macOS menu bar app to control Razer mice: battery, DPI, polling rate, RGB lighting,
 brightness, and software button remapping. Razer's Synapse does not support macOS, so this
 app talks to the mouse directly over USB HID. It is tested on, and works best with, the
-Razer Cobra HyperSpeed and the Razer Atheris. By design it detects and tries to control any
-Razer mouse using the same protocol family, but models beyond those two are untested.
+Razer Cobra HyperSpeed, the Razer Atheris and the Razer Basilisk V3 X HyperSpeed. By design
+it detects and tries to control any Razer mouse using the same protocol family, but models
+beyond those three are untested.
 
 This document explains how the app is built and how every feature works, so a future Claude
 session or a human can pick it up cold. See also:
@@ -91,14 +92,19 @@ Built in [`RazerCommands.swift`](../Sources/MacRazer/RazerCommands.swift). VID `
 | Get / Set DPI | `0x04` / `0x85` / `0x05` | `0x07` | VARSTORE + big-endian x/y; clamp **100-45000** (arbitrary DPI). |
 | Get / Set poll | `0x00` / `0x85` / `0x05` | `0x01` | 1000->`0x01`, 500->`0x02`, 125->`0x08` (basic set only). |
 | Lighting effect | `0x0F` / `0x02` | varies | extended-matrix on **ZERO_LED (0x00)**; effect ids: none `0x00`, static `0x01`, spectrum `0x03`, wave `0x04`. |
-| Get / Set brightness | `0x0F` / `0x84` / `0x04` | `0x03` | value 0-255. **Lives on LOGO_LED (0x04)**, not ZERO_LED, see quirk below. |
+| Get / Set brightness | `0x0F` / `0x84` / `0x04` | `0x03` | value 0-255. LED group is **per model** (`RazerDevices.brightnessLed`), never ZERO_LED — see quirk below. |
 
 ### 3.4 Hardware quirks (discovered by testing, important!)
 - **Battery works over the 2.4 GHz dongle.** The OpenRazer PR author thought it didn't; the
  real fix was the 31 ms wait + targeting the correct interface.
-- **Brightness is on `LOGO_LED` (0x04), not `ZERO_LED`.** Reading brightness on ZERO_LED or
- BACKLIGHT returns status `0x03` (failure). Colors/effects use ZERO_LED; brightness uses
- LOGO_LED. Verified live.
+- **Brightness lives on a different LED group than effects, and which one is per model.**
+ Colors/effects are driven on ZERO_LED for every model so far, but brightness is not: the
+ Cobra family answers only on `LOGO_LED` (0x04), while the Basilisk V3 X HyperSpeed — whose
+ only lit zone is the scroll wheel — answers only on `SCROLL_LED` (0x01). Every other group
+ returns status `0x03` (failure), so a wrong id is not a silent no-op: the brightness slider
+ simply stops working. The id is a registry field (`RazerDevices.brightnessLed`, default
+ `LOGO_LED`); `swift run MacRazer brightness` sweeps all four groups to find it on a new
+ model. Both verified live.
 - **Lighting is one group.** The "4 zones" in marketing aren't independently addressable;
  everything is driven together via ZERO_LED.
 - **Transient garbage on reconnect.** Right after a USB reconnect the battery can read 0x00
@@ -259,7 +265,8 @@ right-click->Open). A clean install needs Developer ID + notarization (paid Appl
 Detection + name display already work for any Razer mouse (read-only, via the USB product
 string). To make the **controls** verified for another model:
 1. Add its PID/name to `RazerDevices.known` with `fullySupported: true` and the right
- `hasBattery`.
+ `hasBattery` / `hasLighting` / `maxDPI`. If its brightness answers on a group other than
+ `LOGO_LED`, set `brightnessLed` too.
 2. Confirm its command dialect matches the Cobra Pro set (transaction id, command variants,
  max DPI, poll rates, LED layout, brightness LED). Port any per-device specifics from
  OpenRazer's `razermouse_driver.c` switch statements / `daemon/.../mouse.py` METHODS.
@@ -281,7 +288,7 @@ swift run MacRazer battery # read battery %
 swift run MacRazer dpi [x] [y] # read / set DPI
 swift run MacRazer poll [125|500|1000]
 swift run MacRazer rgb static ff0000 # or: spectrum | wave | off
-swift run MacRazer brightness [0-100] # probes ZERO/BACKLIGHT/LOGO LEDs
+swift run MacRazer brightness [0-100] # sweeps LOGO/SCROLL/ZERO/BACKLIGHT LEDs
 swift run MacRazer icon out.png # render the menu bar icon
 swift run MacRazer render-ui [offline|color] out.png # render the popover (dev)
 swift run MacRazer render-remap out.png

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="google-site-verification" content="SmhAFHV4KG5IkP0GP-oTNQpCV6aW-Dp_afW9zDSs5NA" />
 <title>MacRazer: Razer mouse control for macOS (free, open source)</title>
-<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Works with Razer Cobra HyperSpeed, Atheris, and Cobra Pro.">
+<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Works with Razer Cobra HyperSpeed, Basilisk V3 X HyperSpeed, Atheris, and Cobra Pro.">
 <meta name="keywords" content="Razer mouse macOS, Razer Synapse alternative Mac, Razer Cobra HyperSpeed Mac, Razer Atheris Mac, Razer mouse driver macOS, Razer DPI macOS, Razer RGB macOS">
 <meta name="author" content="SorcRR">
 <link rel="canonical" href="https://sorcrr.github.io/MacRazer/">
@@ -204,8 +204,16 @@
           <td><span class="badge badge-good">Tested, works best</span></td>
         </tr>
         <tr>
+          <td>Razer Basilisk V3 X HyperSpeed</td>
+          <td><span class="badge badge-good">Tested, works best</span></td>
+        </tr>
+        <tr>
           <td>Razer Basilisk V3</td>
           <td><span class="badge badge-mid">User‑reported working</span></td>
+        </tr>
+        <tr>
+          <td>Razer Basilisk X HyperSpeed</td>
+          <td><span class="badge badge-mid">Same protocol, not yet verified</span></td>
         </tr>
         <tr>
           <td>Razer Cobra, Cobra Pro <span class="muted">(wired + wireless)</span></td>


### PR DESCRIPTION
## Model / PID / features verified

**Razer Basilisk V3 X HyperSpeed**, PID `0x1532:0x00B9`, over the 2.4 GHz dongle. Every control verified on hardware (`status=0x02`):

| Command | Result |
|---|---|
| `battery` | 66% |
| `dpi` | read/write, 6400 |
| `stages` | `[400, 800, 1600, 3200, 6400]` |
| `poll` | 1000 Hz |
| `rgb static` | applies, confirmed visually |
| `brightness` | read/write on `SCROLL_LED` |

Transaction id `0x1f` for every command class, including the DPI-stages pair the Basilisk V3 needs a per-command override for, so this model needs no `transactionOverrides`. It is AA-cell powered, so `is_charging` is always false and it stays off the learned discharge curve.

**Razer Basilisk X HyperSpeed**, PID `0x1532:0x0083`, is ported from the OpenRazer tables only (no lighting, 16000 DPI, `0xFF` transaction ids). I don't have one, so per CONTRIBUTING it's left `fullySupported: false`. Happy to drop it from this PR if you'd rather only carry hardware-verified PIDs.

## Brightness fix

Adding the V3 X surfaced a real bug. The brightness LED group was hardcoded to `LOGO_LED`, but this mouse's only lit zone is the scroll wheel and it answers `FAILURE (0x03)` for everything else, so the brightness slider silently did nothing:

```
LOGO=0x04:      refused (0x03)
SCROLL=0x01:    status=0x2 → 33%
ZERO=0x00:      refused (0x03)
BACKLIGHT=0x05: refused (0x03)
```

Effects and brightness live on different LED groups, and which one answers varies per model, so the id is now a registry field (`brightnessLed`) defaulting to the Cobra family's `LOGO_LED`. Unknown mice behave exactly as before. This follows the CONTRIBUTING guidance to parameterize per device when a model uses a different LED id.

The `brightness` CLI probe also threw on the first refusing LED, so a `LOGO_LED` refusal aborted it before the sweep ran, which is precisely the case it exists for. It now reports LOGO, SCROLL, ZERO and BACKLIGHT individually.

## Also

- Two diagnostics named the Cobra HyperSpeed specifically and were wrong for any other model: the `info` header and the device-not-found error.
- README gains a short "Buttons MacRazer cannot see" section. The Basilisk's third side button is a **multi-function trigger** that ships assigned to Razer Hypershift. Hypershift is resolved in firmware, so pressing it alone puts nothing on the wire. I confirmed this by watching all three of the mouse's HID interfaces while it was pressed: zero input reports, and the mouse interface's report descriptor declares only buttons 1-5. It isn't detectable by any app, so the docs now say so rather than leaving people to wonder.

`swift build && swift test` clean, 80/80. New registry tests cover both PIDs' transaction ids, capabilities and brightness LED mapping. `docs/DOCUMENTATION.md` updated where it documented brightness as living on `LOGO_LED`.