### PR TITLE
Add Razer Orochi 2013 and Viper Ultimate

### DIFF
--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -82,6 +82,10 @@ enum RazerDevices {
         // razermouse_driver.c it takes 0x1f everywhere except the DPI-stages pair, which it
         // shares with the plain Cobra's 0xFF group. Not yet re-verified on hardware by us.
         .init(pid: 0x0099, name: "Razer Basilisk V3", fullySupported: false, hasBattery: false, hasLighting: true, maxDPI: 26000, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
+        // Orochi2013
+        .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: true, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
+        // Viper Ultimate
+        .init(pid: 0x007b, name: "Razer Ultimate", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
     ]
 
     static func info(pid: Int) -> RazerDeviceInfo? { known.first { $0.pid == pid } }

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -85,7 +85,7 @@ enum RazerDevices {
         // Orochi2013
         .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: false, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Viper Ultimate (Wireless)
-        .init(pid: 0x007b, name: "Razer Viper Ultimate (Wireless)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        .init(pid: 0x007b, name: "Razer Viper Ultimate (Wireless)", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Viper Ultimate (Wired)
         .init(pid: 0x007a, name: "Razer Viper Ultimate (Wired)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
     ]

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -83,11 +83,11 @@ enum RazerDevices {
         // shares with the plain Cobra's 0xFF group. Not yet re-verified on hardware by us.
         .init(pid: 0x0099, name: "Razer Basilisk V3", fullySupported: false, hasBattery: false, hasLighting: true, maxDPI: 26000, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Orochi2013
-        .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: false, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
+        .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: false, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Viper Ultimate (Wireless)
-        .init(pid: 0x007b, name: "Razer Viper Ultimate (Wireless)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        .init(pid: 0x007b, name: "Razer Viper Ultimate (Wireless)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Viper Ultimate (Wired)
-        .init(pid: 0x007a, name: "Razer Viper Ultimate (Wired)", fullySupported: false, hasBattery: false, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        .init(pid: 0x007a, name: "Razer Viper Ultimate (Wired)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
     ]
 
     static func info(pid: Int) -> RazerDeviceInfo? { known.first { $0.pid == pid } }

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -83,9 +83,11 @@ enum RazerDevices {
         // shares with the plain Cobra's 0xFF group. Not yet re-verified on hardware by us.
         .init(pid: 0x0099, name: "Razer Basilisk V3", fullySupported: false, hasBattery: false, hasLighting: true, maxDPI: 26000, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Orochi2013
-        .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: true, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
-        // Viper Ultimate
-        .init(pid: 0x007b, name: "Razer Ultimate", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        .init(pid: 0x0039, name: "Razer Orochi 2013", fullySupported: false, hasBattery: false, hasLighting: false, maxDPI: 6400, transactionId: 0x1f, matrixTransactionId: 0x1f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wired, silhouette: .cobra, dischargeCurveModelKey: nil),
+        // Viper Ultimate (Wireless)
+        .init(pid: 0x007b, name: "Razer Viper Ultimate (Wireless)", fullySupported: false, hasBattery: true, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
+        // Viper Ultimate (Wired)
+        .init(pid: 0x007a, name: "Razer Viper Ultimate (Wired)", fullySupported: false, hasBattery: false, hasLighting: true, maxDPI: 20000, transactionId: 0xff, matrixTransactionId: 0x3f, transactionOverrides: [0x0406: 0xff, 0x0486: 0xff], connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
     ]
 
     static func info(pid: Int) -> RazerDeviceInfo? { known.first { $0.pid == pid } }


### PR DESCRIPTION
Add 2 Razer devices:
- Orochi 2013 connected through usb wire: only 3 additionnal buttons of the 5 are detected
- Viper Ultimate: only 3 additionnal buttons of the 5 are detected
