### PR TITLE
Start at login by default, and install updates in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,10 @@ expect rough edges until 1.0.
  ordering — it is written by the caller and read on the URL session's delegate queue, and
  nothing in the code established visibility between the two.
 - Downloaded DMGs no longer accumulate in the temp directory: the manual-download path can't
- delete a file the user still has to open, so each one leaked a few megabytes forever. Stale
- ones are swept at the start of the next download.
+ delete a file the user still has to open, so each one leaked a few megabytes forever. Ones
+ older than an hour are swept at the start of the next download — the age limit matters, since
+ the download handed to Finder a minute ago may not have been opened yet, or may be mounted,
+ and deleting a mounted image's backing file is worse than the leak.
 - `LaunchAtLogin.isSupported` is `@Published`, so changing it actually refreshes the switch.
 - The enlarged charging bolt no longer overlaps the Cobra Pro's DPI clutch button (unreachable
  today — only the generic body ever draws charging — but the triskelion was already guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,56 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Fixed
+- **A verbose `hdiutil` or `ditto` failure could hang an update install forever.** The
+ subprocess helper drained the child's stdout to EOF and only then its stderr; a child that
+ fills the stderr pipe in the meantime blocks, and the parent never stops waiting on stdout.
+ Both pipes are now drained concurrently. The symptom would have been "Installing…" on screen
+ with no timeout and no way out but quitting.
+- **The `login-item` diagnostic no longer turns the login item on.** Registering happened in
+ `LaunchAtLogin.init`, so merely constructing the model — which the read-only report does —
+ changed the user's system and then reported the state it had just created. Applying the
+ default is now an explicit call the app delegate makes at launch.
+- **Apps installed on a second volume get the login item and self-updates again.** Every path
+ under `/Volumes/` was rejected to catch a mounted disk image, which also caught external
+ drives and secondary volumes — those users were told to move MacRazer to an Applications
+ folder it was already in. A disk image is now recognised by being read-only, which is the
+ property that actually distinguishes it from a disk.
+- **A version check landing mid-install can no longer erase the progress bar.** The popover's
+ update card is mounted on `latestVersion`, so a background check resolving to "nothing
+ newer" during a download or bundle swap made the whole card vanish while the install carried
+ on invisibly. Checks are now skipped while one is in flight.
+- **A failed manual "Check for Updates…" no longer spends the user's dismissal.** The
+ dismissed version was cleared before the request; if that then failed, the dismissal was gone
+ and the previously-waved-away version came back having learned nothing. It's cleared only
+ once a check succeeds.
+- **The installed copy is verified, not just the one on the disk image.** The signature was
+ checked on the mounted payload and a `ditto` copy of it was what actually got installed —
+ the artifact placed on disk was never itself verified, in the last moment before a working
+ app is unlinked.
+- **Copy and swap failures now say what went wrong.** Both carried the underlying `ditto`
+ stderr or `FileManager` error and both threw it away; that detail now goes to stderr, as
+ elsewhere in the app. These are the hardest install failures to reproduce and were the only
+ ones reporting nothing.
+- **The download delegate's shared state is under a lock** rather than under an argument about
+ ordering — it is written by the caller and read on the URL session's delegate queue, and
+ nothing in the code established visibility between the two.
+- Downloaded DMGs no longer accumulate in the temp directory: the manual-download path can't
+ delete a file the user still has to open, so each one leaked a few megabytes forever. Stale
+ ones are swept at the start of the next download.
+- `LaunchAtLogin.isSupported` is `@Published`, so changing it actually refreshes the switch.
+- The enlarged charging bolt no longer overlaps the Cobra Pro's DPI clutch button (unreachable
+ today — only the generic body ever draws charging — but the triskelion was already guarded
+ for exactly this reason).
+- Removed `UpdateInstallError.notInstalled`, which carried a user-facing message it could
+ never show.
+
 ### Added
+- **Tests for the in-place installer itself**, against real signed bundles inside real disk
+ images — the one code path that deletes the user's installed application had no automated
+ coverage at all, only unit tests of the pure predicate feeding it. Every refusal (older
+ payload, same version, wrong app, tampered bundle, unmountable image, image with no app)
+ asserts the installed bundle is still there and still the old version.
 - **"Start MacRazer at login" (on by default) in the popover's settings card.** A menu bar
  battery meter that silently stops existing after every reboot, until you remember to go and
  open it, isn't a battery meter. Backed by `SMAppService.mainApp`, so MacRazer also appears

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ expect rough edges until 1.0.
  reads as the same mouse. The Razer triskelion is no longer drawn in the charging variant —
  the bolt occupies the space it sat in, and two marks on top of each other read as neither
  (the menu bar never drew it anyway; this keeps every other caller sane).
+- **And the bolt is yellow.** That costs the charging mark its template-image status: macOS
+ recolors template images to match the menu bar and throws any colour in them away — the same
+ reason the update dot is a subview rather than part of the icon. So the charging icon is now
+ drawn for a specific menu bar instead: white body with a bright yellow bolt on a dark one,
+ black body with a deeper amber on a light one, because system yellow vanishes against white.
+ It's repainted when the menu bar switches between light and dark, which the template image
+ used to get for free. The idle mark is untouched and still a template. `MacRazer icon …
+ charging light` previews the light-mode pairing.
 - **"Check for Updates…" in the menu bar right-click menu.** The background check runs once a
  day; this asks for one now, and is the only way back to the update card after dismissing a
  version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Added
+- **"Start MacRazer at login" (on by default) in the popover's settings card.** A menu bar
+ battery meter that silently stops existing after every reboot, until you remember to go and
+ open it, isn't a battery meter. Backed by `SMAppService.mainApp`, so MacRazer also appears
+ in System Settings › General › Login Items and can be switched off from there — the toggle
+ reads the system's registration rather than a preference of its own, and re-reads it
+ whenever the app comes back to the foreground, so the two can't disagree. The default is
+ applied exactly once, on the first launch of a build that has it; after that the user's
+ choice is the record and no later launch undoes it. The switch is disabled, with an
+ explanation, when the app is running from the mounted DMG, from a translocated copy, or
+ under `swift run` — a login item recorded at any of those paths points at nothing after a
+ reboot.
+- **"Update & Restart": the update card now installs the update instead of handing you a
+ DMG to drag.** Downloads with a real progress bar (a multi-megabyte download behind a bare
+ spinner is indistinguishable from a hang), then mounts the image, checks that what's inside
+ really is a newer MacRazer with an intact code signature, swaps the bundle atomically and
+ relaunches into the new version. The swap is in place — same path, same signing identity —
+ which is what keeps the Input Monitoring grant and the login item pointing at the app
+ instead of silently costing you both. Nothing is deleted until a verified replacement is
+ staged, so a refused or failed install leaves the working app exactly where it was.
+ Wherever an in-place install isn't possible (running from the image itself, a translocated
+ copy, or a folder you can't write to) the card falls back to the old download-the-DMG
+ behaviour, and offers that as a second chance if an install fails.
+- **A `login-item [on|off]` CLI diagnostic.** The login-item registration is the one piece of
+ app state that lives in the system rather than in MacRazer's own defaults, so it can't be
+ checked by reading a file; this reports it, and `on`/`off` drive the same code the popover
+ switch does — which also makes it the repair path when the menu bar item isn't reachable.
+- **The version in the popover footer is now a link to the project page.** A menu bar app has
+ nowhere to put an "About", and that line is already where people look to answer "what am I
+ running" — so it doubles as the way there instead of costing the popover another row. It
+ stays quiet at rest and picks up the accent colour and an underline on hover.
+- **"Check for Updates…" in the menu bar right-click menu.** The background check runs once a
+ day; this asks for one now, and is the only way back to the update card after dismissing a
+ version.
+
 ## [0.2.1] — 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ expect rough edges until 1.0.
  nowhere to put an "About", and that line is already where people look to answer "what am I
  running" — so it doubles as the way there instead of costing the popover another row. It
  stays quiet at rest and picks up the accent colour and an underline on hover.
+- **The charging bolt in the menu bar icon now fills the mouse body.** It was drawn to the
+ scale of the button-split line it replaces — which is a detail, not a signal, and at ~21pt
+ in a menu bar seen out of the corner of the eye it read as a smudge rather than a bolt. It
+ now spans from just under the scroll wheel to just inside the base, with clearance at both
+ ends so it never merges into the silhouette. The body shape is untouched, so the icon still
+ reads as the same mouse. The Razer triskelion is no longer drawn in the charging variant —
+ the bolt occupies the space it sat in, and two marks on top of each other read as neither
+ (the menu bar never drew it anyway; this keeps every other caller sane).
 - **"Check for Updates…" in the menu bar right-click menu.** The background check runs once a
  day; this asks for one now, and is the only way back to the update card after dismissing a
  version.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Razer mice that use the same HID protocol family, but those are untested, so tre
   (no lighting on the Atheris, no battery UI on wired-only mice).
 - Settings are written to the mouse's **onboard memory** where supported, so they persist when
   the app is not running.
+- **Starts at login** (on by default, switchable in the popover and in System Settings ›
+  General › Login Items), so the menu bar item is there after a reboot.
+- **Updates install themselves**: when a new release is out, "Update & Restart" downloads it,
+  checks it, replaces the installed app and relaunches — no dragging a DMG. It falls back to
+  the plain DMG download when MacRazer is somewhere it can't replace itself (still on the disk
+  image, or in a folder you can't write to).
 
 Settings persist across app restarts and reconnects, and the menu bar updates on its own when
 the mouse connects, disconnects, or sleeps.

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -32,6 +32,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         // user without it is always walked through it rather than left with a silently-dead app.
         // Button remapping additionally needs Accessibility (optional; surfaced in the same window).
         permissions.recheck()
+        // Explicit, not a side effect of constructing the model — see the doc comment there.
+        launchAtLogin.applyDefaultOnFirstRun()
         LowBatteryNotifier.configureNotifications(delegate: self)
         // A manual button-remap edit (outside applying a profile) means the live config no
         // longer matches whichever profile was last applied — let MouseController know so it

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -23,6 +23,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     private let launchAtLogin = LaunchAtLogin()
     private var updateTimer: Timer?
     private var updateBadgeView: NSView?
+    private var appearanceObserver: NSKeyValueObservation?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Razer HID devices enumerate as a keyboard/mouse, so macOS gates opening them behind
@@ -41,7 +42,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         }
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusItem.button?.image = Self.menuBarIcon(charging: false)
+        statusItem.button?.image = menuBarIcon(charging: false)
         statusItem.button?.imagePosition = .imageLeading
         statusItem.button?.imageHugsTitle = true
         statusItem.button?.title = " …"
@@ -85,7 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] charging in
-                self?.statusItem.button?.image = Self.menuBarIcon(charging: charging)
+                self?.statusItem.button?.image = self?.menuBarIcon(charging: charging)
             }
             .store(in: &cancellables)
 
@@ -154,6 +155,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         }
         RunLoop.main.add(timer, forMode: .common)
         updateTimer = timer
+
+        // The charging mark is drawn for one appearance; watch for the menu bar flipping.
+        appearanceObserver = statusItem.button?.observe(\.effectiveAppearance) { [weak self] _, _ in
+            Task { @MainActor in self?.refreshMenuBarIcon() }
+        }
     }
 
     /// Small red dot over the status-item icon when an update is available. A subview rather
@@ -295,16 +301,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     func applicationWillTerminate(_ notification: Notification) {
         monitor?.invalidate()
         updateTimer?.invalidate()
+        appearanceObserver?.invalidate()
         controller.flushHistoryToDisk()
     }
 
     // MARK: - Menu bar mark
 
-    /// The status-item mark, in its idle and charging variants. Drawing is cheap but this
-    /// runs on every charge-state change for the app's lifetime, so both are built once.
+    /// The status-item mark. The idle one is a template image macOS recolors itself, so it is
+    /// drawn once and reused. The charging one carries a yellow bolt, which a template image
+    /// would discard — so it is drawn for a specific appearance and has to be redrawn when
+    /// that changes (see `appearanceObserver`). Both only happen on plug/unplug or a theme
+    /// switch, so the redraw costs nothing worth caching around.
     private static let idleIcon = MenuBarIcon.mouse(pointSize: 21, razerCutout: false)
-    private static let chargingIcon = MenuBarIcon.mouse(pointSize: 21, razerCutout: false, charging: true)
-    private static func menuBarIcon(charging: Bool) -> NSImage { charging ? chargingIcon : idleIcon }
+
+    private func menuBarIcon(charging: Bool) -> NSImage {
+        guard charging else { return Self.idleIcon }
+        return MenuBarIcon.mouse(pointSize: 21, razerCutout: false, charging: true,
+                                 appearance: statusItem.button?.effectiveAppearance)
+    }
+
+    /// Repaint the charging mark when the menu bar flips between light and dark. Nothing else
+    /// does it for us: the idle mark is a template image and adapts on its own, but the
+    /// coloured charging one is a fixed bitmap for whichever appearance drew it.
+    private func refreshMenuBarIcon() {
+        statusItem?.button?.image = menuBarIcon(charging: controller.charging)
+    }
 
     // MARK: - Notifications
 

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     private lazy var permissions = PermissionsModel(remapper: remapper, controller: controller)
     private lazy var permissionsWindow = PermissionsWindowController(model: permissions, controller: controller)
     private let updateChecker = UpdateChecker()
+    private let launchAtLogin = LaunchAtLogin()
     private var updateTimer: Timer?
     private var updateBadgeView: NSView?
 
@@ -56,7 +57,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         // logo have poor contrast on the light-mode grey material; dark is also the gaming
         // aesthetic and makes the green pop.
         popover.appearance = NSAppearance(named: .darkAqua)
-        let hosting = NSHostingController(rootView: PopoverView(controller: controller, remapper: remapper, updateChecker: updateChecker))
+        let hosting = NSHostingController(rootView: PopoverView(controller: controller, remapper: remapper, updateChecker: updateChecker, launchAtLogin: launchAtLogin))
         hosting.sizingOptions = [.preferredContentSize] // popover auto-fits the SwiftUI content
         popover.contentViewController = hosting
 
@@ -233,6 +234,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         setup.target = self
         menu.addItem(setup)
 
+        // The background check runs once a day; this is the way to ask for one now, and it
+        // also un-dismisses a version the user waved away earlier.
+        let update = NSMenuItem(title: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        update.target = self
+        menu.addItem(update)
+
         menu.addItem(.separator())
 
         let quit = NSMenuItem(title: "Quit MacRazer", action: #selector(quit), keyEquivalent: "q")
@@ -255,6 +262,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     }
 
     @objc private func refreshNow() { controller.refreshAll() }
+    @objc private func checkForUpdates() {
+        Task {
+            await updateChecker.checkForUpdatesNow(userRequested: true)
+            // Open the popover either way: with an update it shows the card, without one it
+            // shows the version in the footer — both answer "am I up to date?".
+            if !popover.isShown { togglePopover() }
+        }
+    }
     @objc private func openRemap() { remapWindow.show() }
     @objc private func openPermissions() { permissionsWindow.show() }
     @objc private func quit() { NSApplication.shared.terminate(nil) }
@@ -271,8 +286,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     func applicationDidBecomeActive(_ notification: Notification) {
         permissions.recheck()
         // Same reason as the permission recheck: the user may have just flipped the
-        // Notifications switch in System Settings and come back.
+        // Notifications switch — or MacRazer's Login Items entry — in System Settings and
+        // come back.
         controller.refreshNotificationAuthorization()
+        launchAtLogin.refresh()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/MacRazer/AppLocation.swift
+++ b/Sources/MacRazer/AppLocation.swift
@@ -7,25 +7,31 @@ import Foundation
 /// updater both have to agree on before they act.
 ///
 /// Each feature writes down (or overwrites) a path that must still mean "MacRazer" later:
-/// after a reboot for the login item, after the swap for the updater. Three locations break
-/// that promise and are treated as "not installed yet":
+/// after a reboot for the login item, after the swap for the updater. What breaks that
+/// promise:
 ///
-/// - **a mounted disk image** (`/Volumes/…`) — the app is being run straight out of the DMG
-///   without ever being dragged to Applications; the path is gone on eject, and the volume is
-///   read-only besides;
 /// - **app translocation** (`…/AppTranslocation/…`) — Gatekeeper's randomized read-only copy
 ///   of a still-quarantined app, discarded when it quits;
-/// - **the temp directories** — a staging copy, never an installation.
+/// - **the temp directories** — a staging copy, never an installation;
+/// - **a read-only volume** — overwhelmingly a mounted disk image, i.e. the app run straight
+///   out of the DMG without ever being dragged across.
 ///
 /// A bundle that isn't an `.app` at all covers the remaining case: `swift run`, where
 /// `Bundle.main` is the SwiftPM binary's directory in `.build`.
+///
+/// Note what is deliberately *not* here: a `/Volumes/` prefix. Mounted images live there, but
+/// so do secondary internal volumes and external drives where people quite reasonably keep
+/// their applications — banning the prefix outright told those users to "move MacRazer to
+/// your Applications folder" when it already was in one. Read-only is the property that
+/// actually separates a disk image from a disk.
 enum AppLocation {
     /// Locations that exist for one session, not for the next boot.
     private static let transientPrefixes = [
-        "/Volumes/", "/private/var/folders/", "/var/folders/", "/private/tmp/", "/tmp/",
+        "/private/var/folders/", "/var/folders/", "/private/tmp/", "/tmp/",
     ]
 
-    /// Whether `path` is somewhere a login item or an in-place update may point at.
+    /// The path-shape half of the test — pure, so it stays unit-testable. `installedBundleURL`
+    /// adds the volume check, which needs the filesystem.
     static func isStableInstall(_ path: String) -> Bool {
         // A trailing slash is legal in a bundle path and would defeat the suffix check.
         var p = path
@@ -41,6 +47,15 @@ enum AppLocation {
     /// from a mounted image, or when translocated.
     static var installedBundleURL: URL? {
         let url = Bundle.main.bundleURL
-        return isStableInstall(url.path) ? url : nil
+        guard isStableInstall(url.path), !isOnReadOnlyVolume(url) else { return nil }
+        return url
+    }
+
+    /// A read-only volume can't hold an install we could update, and a login item pointing
+    /// into one is pointing at something ejectable. An unreadable resource value is treated as
+    /// writable: failing open keeps a working install working, and the updater checks
+    /// writability again for itself before it touches anything.
+    private static func isOnReadOnlyVolume(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.volumeIsReadOnlyKey]))?.volumeIsReadOnly ?? false
     }
 }

--- a/Sources/MacRazer/AppLocation.swift
+++ b/Sources/MacRazer/AppLocation.swift
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// Where the running app bundle lives — the one fact "start at login" and the in-place
+/// updater both have to agree on before they act.
+///
+/// Each feature writes down (or overwrites) a path that must still mean "MacRazer" later:
+/// after a reboot for the login item, after the swap for the updater. Three locations break
+/// that promise and are treated as "not installed yet":
+///
+/// - **a mounted disk image** (`/Volumes/…`) — the app is being run straight out of the DMG
+///   without ever being dragged to Applications; the path is gone on eject, and the volume is
+///   read-only besides;
+/// - **app translocation** (`…/AppTranslocation/…`) — Gatekeeper's randomized read-only copy
+///   of a still-quarantined app, discarded when it quits;
+/// - **the temp directories** — a staging copy, never an installation.
+///
+/// A bundle that isn't an `.app` at all covers the remaining case: `swift run`, where
+/// `Bundle.main` is the SwiftPM binary's directory in `.build`.
+enum AppLocation {
+    /// Locations that exist for one session, not for the next boot.
+    private static let transientPrefixes = [
+        "/Volumes/", "/private/var/folders/", "/var/folders/", "/private/tmp/", "/tmp/",
+    ]
+
+    /// Whether `path` is somewhere a login item or an in-place update may point at.
+    static func isStableInstall(_ path: String) -> Bool {
+        // A trailing slash is legal in a bundle path and would defeat the suffix check.
+        var p = path
+        while p.count > 1, p.hasSuffix("/") { p.removeLast() }
+        guard p.hasPrefix("/"), p.hasSuffix(".app") else { return false }
+        // Translocation mounts appear under /private/var/folders too, but the marker is what
+        // makes the intent legible in a crash report or a log line.
+        if p.contains("/AppTranslocation/") { return false }
+        return !transientPrefixes.contains { p.hasPrefix($0) }
+    }
+
+    /// The running app's bundle when it is a real, installed `.app` — nil under `swift run`,
+    /// from a mounted image, or when translocated.
+    static var installedBundleURL: URL? {
+        let url = Bundle.main.bundleURL
+        return isStableInstall(url.path) ? url : nil
+    }
+}

--- a/Sources/MacRazer/LaunchAtLogin.swift
+++ b/Sources/MacRazer/LaunchAtLogin.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+import ServiceManagement
+
+/// "Start MacRazer at login", backed by `SMAppService.mainApp` — the modern login-item API
+/// (macOS 13+; the app targets 14), which is also what puts MacRazer in System Settings ›
+/// General › Login Items so it can be switched off from outside the app.
+///
+/// **On by default.** A menu bar battery meter that silently stops existing after every
+/// reboot, until you remember to go and open it, isn't a battery meter. The default is
+/// applied at most once — the first launch of a build that has this feature — and only from a
+/// real installed location. After that the user's choice is the record: turning it off here,
+/// or in System Settings, is never undone by a later launch.
+@MainActor
+final class LaunchAtLogin: ObservableObject {
+    /// Mirrors the *system's* registration rather than a preference of our own, and is re-read
+    /// on demand: the user can flip this in System Settings without going through the app, and
+    /// a switch that disagrees with Login Items is worse than no switch.
+    @Published private(set) var isEnabled = false
+    /// The item is registered but macOS wants the user to approve it before honouring it.
+    /// Shown as on — that is what the app asked for — with a pointer to where to finish it.
+    @Published private(set) var needsApproval = false
+    /// A failed register/unregister, so the switch explains itself instead of just springing
+    /// back to where it was.
+    @Published private(set) var lastError: String?
+
+    /// False under `swift run`, and when the app is running from a mounted DMG or a
+    /// translocated copy: a login item recorded there points at a path that won't be MacRazer
+    /// (or won't exist) at the next boot. See `AppLocation`.
+    private(set) var isSupported: Bool
+
+    private static let appliedDefaultKey = "launchAtLoginDefaultApplied"
+
+    init() {
+        isSupported = AppLocation.installedBundleURL != nil
+        refresh()
+        applyDefaultOnFirstRun()
+    }
+
+    /// Re-read the system's view. Cheap, and called whenever the app comes back to the
+    /// foreground — the user may have just toggled MacRazer in System Settings and switched
+    /// back, exactly as with the permission rechecks.
+    func refresh() {
+        guard isSupported else {
+            isEnabled = false
+            needsApproval = false
+            return
+        }
+        let status = SMAppService.mainApp.status
+        isEnabled = status == .enabled || status == .requiresApproval
+        needsApproval = status == .requiresApproval
+    }
+
+    func setEnabled(_ on: Bool) {
+        guard isSupported else { return }
+        lastError = nil
+        // Whichever way this goes, the user has now expressed a choice — record that the
+        // default no longer applies, so a failure here doesn't get silently "corrected" by
+        // the first-run default on the next launch.
+        UserDefaults.standard.set(true, forKey: Self.appliedDefaultKey)
+        do {
+            // Both calls throw when the service is already in the requested state, and the
+            // switch can be driven from a published value that a System Settings change has
+            // made stale — so decide from the live status, not from `isEnabled`.
+            let status = SMAppService.mainApp.status
+            let registered = status == .enabled || status == .requiresApproval
+            if on, !registered {
+                try SMAppService.mainApp.register()
+            } else if !on, registered {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            lastError = on
+                ? "Couldn't turn this on — add MacRazer in System Settings › General › Login Items."
+                : "Couldn't turn this off — remove MacRazer in System Settings › General › Login Items."
+        }
+        refresh()
+    }
+
+    func openLoginItemsSettings() { SMAppService.openSystemSettingsLoginItems() }
+
+    /// The switch as an installed copy sees it, for the `render-ui` preview — `swift run` has
+    /// no bundle, so the real state there is always the disabled one.
+    func loadPreviewState() {
+        isSupported = true
+        isEnabled = true
+        needsApproval = false
+    }
+
+    /// The default, applied once. Failure is deliberately *not* recorded as applied: the most
+    /// likely cause is a first launch macOS hasn't settled yet, and the retry next launch
+    /// costs nothing, whereas recording it would quietly cost the user the feature forever.
+    private func applyDefaultOnFirstRun() {
+        guard isSupported, !UserDefaults.standard.bool(forKey: Self.appliedDefaultKey) else { return }
+        // Already registered — the user added MacRazer to Login Items by hand under an older
+        // build. Nothing to do, and nothing to undo later.
+        guard !isEnabled else {
+            UserDefaults.standard.set(true, forKey: Self.appliedDefaultKey)
+            return
+        }
+        do {
+            try SMAppService.mainApp.register()
+            UserDefaults.standard.set(true, forKey: Self.appliedDefaultKey)
+        } catch {
+            // Silent: an automatic default that failed is not something to interrupt a first
+            // launch over. The switch shows the real state either way.
+        }
+        refresh()
+    }
+}

--- a/Sources/MacRazer/LaunchAtLogin.swift
+++ b/Sources/MacRazer/LaunchAtLogin.swift
@@ -29,14 +29,13 @@ final class LaunchAtLogin: ObservableObject {
     /// False under `swift run`, and when the app is running from a mounted DMG or a
     /// translocated copy: a login item recorded there points at a path that won't be MacRazer
     /// (or won't exist) at the next boot. See `AppLocation`.
-    private(set) var isSupported: Bool
+    @Published private(set) var isSupported: Bool
 
     private static let appliedDefaultKey = "launchAtLoginDefaultApplied"
 
     init() {
         isSupported = AppLocation.installedBundleURL != nil
         refresh()
-        applyDefaultOnFirstRun()
     }
 
     /// Re-read the system's view. Cheap, and called whenever the app comes back to the
@@ -89,10 +88,18 @@ final class LaunchAtLogin: ObservableObject {
         needsApproval = false
     }
 
-    /// The default, applied once. Failure is deliberately *not* recorded as applied: the most
-    /// likely cause is a first launch macOS hasn't settled yet, and the retry next launch
-    /// costs nothing, whereas recording it would quietly cost the user the feature forever.
-    private func applyDefaultOnFirstRun() {
+    /// The default, applied once — called explicitly by `AppDelegate` at launch, deliberately
+    /// **not** from `init`.
+    ///
+    /// Registering a login item is a change to the user's system, and it must not be something
+    /// merely constructing this object does: `main.swift`'s `login-item` command builds one to
+    /// *report* status, and while this lived in the initializer that read-only diagnostic
+    /// turned the login item on and then reported the state it had just created.
+    ///
+    /// Failure is deliberately not recorded as applied: the most likely cause is a first
+    /// launch macOS hasn't settled yet, and the retry next launch costs nothing, whereas
+    /// recording it would quietly cost the user the feature forever.
+    func applyDefaultOnFirstRun() {
         guard isSupported, !UserDefaults.standard.bool(forKey: Self.appliedDefaultKey) else { return }
         // Already registered — the user added MacRazer to Login Items by hand under an older
         // build. Nothing to do, and nothing to undo later.

--- a/Sources/MacRazer/MenuBarIcon.swift
+++ b/Sources/MacRazer/MenuBarIcon.swift
@@ -66,8 +66,8 @@ enum MenuBarIcon {
                                cornerWidth: wheelW / 2, cornerHeight: wheelW / 2, transform: nil)
             ctx.addPath(wheel)
 
-            // Button-split line below the wheel — replaced by a charging bolt in the same
-            // slot, so the body silhouette stays identical and only the detail changes.
+            // Button-split line below the wheel — replaced by the charging bolt below, so the
+            // body silhouette stays identical and only what's inside it changes.
             if !charging {
                 ctx.move(to: P(0, 0.13))
                 ctx.addLine(to: P(0, -0.10))
@@ -94,7 +94,14 @@ enum MenuBarIcon {
             if charging {
                 // Classic 6-point flash, in units of the bolt's own half-width/half-height
                 // so the proportions hold at any icon size.
-                let boltHalfW = 0.16, boltHalfH = 0.145, yOff: CGFloat = 0.015
+                //
+                // Sized to fill the body rather than to replace the button-split line it
+                // stands in for: this mark is read at ~21pt in a menu bar, out of the corner
+                // of the eye, and a detail-sized glyph there is a smudge. It spans from just
+                // under the scroll wheel (0.16) down to just inside the base stroke (-0.46
+                // plus half the line width), keeping a hair of clearance at both ends so the
+                // bolt never merges into the silhouette.
+                let boltHalfW = 0.31, boltHalfH = 0.275, yOff: CGFloat = -0.128
                 func B(_ x: CGFloat, _ y: CGFloat) -> CGPoint { P(x * boltHalfW, y * boltHalfH + yOff) }
                 let bolt = CGMutablePath()
                 bolt.move(to: B(0.35, 1.00))     // top tip
@@ -109,8 +116,11 @@ enum MenuBarIcon {
                 ctx.fillPath()
             }
 
-            // Triskelion mark near the base.
-            if razerCutout {
+            // Triskelion mark near the base — but not while charging: the bolt now occupies
+            // the body the triskelion sits in, and two marks on top of each other read as
+            // neither. The menu bar passes `razerCutout: false` anyway; this keeps the
+            // charging variant sane for every other caller.
+            if razerCutout && !charging {
                 let center = P(0, -0.29)
                 let r = s * 0.105
                 for k in 0..<3 {

--- a/Sources/MacRazer/MenuBarIcon.swift
+++ b/Sources/MacRazer/MenuBarIcon.swift
@@ -7,11 +7,38 @@ import AppKit
 /// `RazerDevices` — the registry — so adding a mouse doesn't touch drawing code.)
 enum MenuBarIcon {
 
+    /// Razer yellow-green is the brand's; this is a battery-charging yellow, picked to read
+    /// against a menu bar rather than to match the logo. Two of them, because one doesn't
+    /// work in both places: system yellow disappears into a white menu bar, and the darker
+    /// amber that fixes that looks muddy on black.
+    static let chargingYellowOnDark = NSColor(red: 1.00, green: 0.84, blue: 0.13, alpha: 1)  // #FFD621
+    static let chargingYellowOnLight = NSColor(red: 0.85, green: 0.58, blue: 0.00, alpha: 1) // #D99400
+
     /// A mouse silhouette with a small Razer triskelion cut into the body (even-odd).
-    /// Template image for the menu bar. `charging` swaps the button-split line for a bolt.
-    static func mouse(pointSize: CGFloat = 16, razerCutout: Bool = true, charging: Bool = false) -> NSImage {
-        let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: .cobra, charging: charging)
-        img.isTemplate = true
+    ///
+    /// The idle mark is a **template** image: macOS recolors it for a light or dark menu bar,
+    /// and inverts it while the item is highlighted, all for free.
+    ///
+    /// The charging mark cannot be, because a template image throws colour away — the same
+    /// reason `AppDelegate` draws the update dot as a subview instead of baking it in. So the
+    /// bolt's yellow costs us the automatic recolouring, and the body colour has to be chosen
+    /// here from `appearance`. `AppDelegate` passes the status item's own effective appearance
+    /// and rebuilds this icon when it changes, since nothing else will.
+    static func mouse(pointSize: CGFloat = 16, razerCutout: Bool = true, charging: Bool = false,
+                      appearance: NSAppearance? = nil) -> NSImage {
+        guard charging else {
+            let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: .cobra)
+            img.isTemplate = true
+            return img
+        }
+        // `currentDrawing()` is the sensible fallback: off the main actor there is no
+        // NSApp to ask, and a caller drawing into a context has already set it.
+        let isDark = (appearance ?? .currentDrawing())
+            .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let img = drawMouse(size: pointSize, razerCutout: razerCutout, silhouette: .cobra,
+                            color: isDark ? .white : .black, charging: true,
+                            boltColor: isDark ? chargingYellowOnDark : chargingYellowOnLight)
+        img.isTemplate = false
         return img
     }
 
@@ -27,8 +54,11 @@ enum MenuBarIcon {
         return img
     }
 
+    /// `boltColor` defaults to `color` so every non-menu-bar caller (previews, the app icon)
+    /// keeps drawing a single-colour mark.
     private static func drawMouse(size s: CGFloat, razerCutout: Bool, silhouette: RazerMouseSilhouette,
-                                  color: NSColor = .black, charging: Bool = false) -> NSImage {
+                                  color: NSColor = .black, charging: Bool = false,
+                                  boltColor: NSColor? = nil) -> NSImage {
         NSImage(size: NSSize(width: s, height: s), flipped: false) { rect in
             guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
             let cx = rect.midX, cy = rect.midY
@@ -112,7 +142,7 @@ enum MenuBarIcon {
                 bolt.addLine(to: B(0.00, -0.05)) // jog back to centre
                 bolt.closeSubpath()
                 ctx.addPath(bolt)
-                ctx.setFillColor(color.cgColor)
+                ctx.setFillColor((boltColor ?? color).cgColor)
                 ctx.fillPath()
             }
 
@@ -171,10 +201,18 @@ enum MenuBarIcon {
     /// Render a mark to a PNG file (used by the `icon` CLI command for visual verification).
     @discardableResult
     static func writePreview(to path: String, size: CGFloat, silhouette: RazerMouseSilhouette = .cobra,
-                             razerCutout: Bool = true, charging: Bool = false) -> Bool {
+                             razerCutout: Bool = true, charging: Bool = false,
+                             lightMenuBar: Bool = false) -> Bool {
+        // Charging previews reproduce a real menu-bar pairing — body and bolt colour both
+        // depend on it, and the light one is the harder of the two to get right (yellow on
+        // white). Non-charging keeps the brand green: it's a shape check, not a colour one.
         let image = drawMouse(size: size, razerCutout: razerCutout, silhouette: silhouette,
-                              color: NSColor(red: 0x44/255, green: 0xD6/255, blue: 0x2C/255, alpha: 1),
-                              charging: charging)
+                              color: charging ? (lightMenuBar ? .black : .white)
+                                  : NSColor(red: 0x44/255, green: 0xD6/255, blue: 0x2C/255, alpha: 1),
+                              charging: charging,
+                              boltColor: charging
+                                  ? (lightMenuBar ? chargingYellowOnLight : chargingYellowOnDark)
+                                  : nil)
         let px = Int(size)
         guard let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil, pixelsWide: px, pixelsHigh: px,
@@ -184,8 +222,9 @@ enum MenuBarIcon {
 
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
-        // Dark backdrop so the mark is visible in the preview.
-        NSColor(white: 0.12, alpha: 1).setFill()
+        // Backdrop matches the menu bar being previewed — a light-mode mark on a dark square
+        // would tell you nothing about the contrast that actually matters.
+        (lightMenuBar ? NSColor(white: 0.93, alpha: 1) : NSColor(white: 0.12, alpha: 1)).setFill()
         NSRect(x: 0, y: 0, width: CGFloat(px), height: CGFloat(px)).fill()
         image.draw(in: NSRect(x: 0, y: 0, width: CGFloat(px), height: CGFloat(px)))
         NSGraphicsContext.restoreGraphicsState()

--- a/Sources/MacRazer/MenuBarIcon.swift
+++ b/Sources/MacRazer/MenuBarIcon.swift
@@ -112,7 +112,11 @@ enum MenuBarIcon {
             }
 
             // Cobra Pro/HyperSpeed add a visible on-the-fly DPI clutch button behind the wheel.
-            if silhouette == .cobraPro {
+            // Suppressed while charging for the same reason as the triskelion below: the
+            // enlarged bolt runs straight through this rect, and two marks overlapping read as
+            // neither. Unreachable today (only `.cobra` ever charges), but the next per-model
+            // charging icon should not have to rediscover it.
+            if silhouette == .cobraPro && !charging {
                 let dpi = CGRect(x: cx - wheelW * 0.55, y: cy - 0.02 * s, width: wheelW * 1.1, height: s * 0.05)
                 ctx.addPath(CGPath(roundedRect: dpi, cornerWidth: s * 0.025, cornerHeight: s * 0.025, transform: nil))
             }

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -25,6 +25,7 @@ struct PopoverView: View {
     @ObservedObject var controller: MouseController
     @ObservedObject var remapper: ButtonRemapper
     @ObservedObject var updateChecker: UpdateChecker
+    @ObservedObject var launchAtLogin: LaunchAtLogin
 
     enum Page { case main, color, buttons, usage, profiles }
     @State private var page: Page = .main
@@ -38,6 +39,7 @@ struct PopoverView: View {
     @State private var color: Color = .razerGreen
     /// Recallable custom DPI — persisted per-mouse, and never above the mouse's max.
     @State private var customDPI: Int = 8000
+    @State private var versionHovered = false
 
     private let pollRates = RazerCommands.supportedPollingRates
     private let defaultStages = [400, 800, 1600, 3200, 6400]
@@ -162,7 +164,7 @@ struct PopoverView: View {
             // Profiles bundle the sections above (plus remaps) into presets — placed after
             // them so the page reads "here are the controls, here's how to save/recall them".
             profilesCard.disabled(!controller.connected).opacity(controller.connected ? 1 : 0.45)
-            if controller.deviceHasBattery { settingsCard }
+            settingsCard
             footer
         }
         .padding(12)
@@ -426,41 +428,95 @@ struct PopoverView: View {
                         .font(.system(size: 11)).foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 0)
-                Button {
-                    updateChecker.dismiss(version)
-                } label: {
-                    Image(systemName: "xmark").font(.system(size: 9, weight: .bold))
+                // No way out mid-install: dismissing wouldn't stop the swap, it would just
+                // hide the only thing telling the user what's happening.
+                if !updateChecker.isBusy {
+                    Button {
+                        updateChecker.dismiss(version)
+                    } label: {
+                        Image(systemName: "xmark").font(.system(size: 9, weight: .bold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tertiary)
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.tertiary)
             }
             if let error = updateChecker.downloadError {
                 Text(error).font(.system(size: 10.5)).foregroundStyle(Color.batteryLow)
             }
-            Button {
-                Task { await updateChecker.downloadAndOpenDMG() }
-            } label: {
-                HStack(spacing: 6) {
-                    if updateChecker.isDownloading {
-                        ProgressView().controlSize(.small)
-                        Text("Downloading…")
-                    } else {
-                        Image(systemName: "arrow.down.to.line")
-                        Text("Download")
-                    }
-                }
-                .font(.system(size: 11.5, weight: .medium))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 5)
+            switch updateChecker.phase {
+            case .idle: updateActionButton
+            case .downloading(let fraction): updateProgress(fraction)
+            case .installing: updateBusyLabel("Installing…")
+            case .restarting: updateBusyLabel("Restarting…")
+            case .needsRestart: updateNeedsRestart
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.razerGreen)
-            .controlSize(.small)
-            .disabled(updateChecker.isDownloading)
+            // After a failed in-place install the manual route still works — offer it rather
+            // than leaving "install it manually" as advice with no button attached.
+            if updateChecker.downloadError != nil, !updateChecker.isBusy, updateChecker.canInstallInPlace {
+                Button("Download the DMG instead") {
+                    Task { await updateChecker.downloadAndOpenDMG() }
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 11))
+                .foregroundStyle(Color.razerGreen)
+            }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.razerGreen.opacity(0.12), in: RoundedRectangle(cornerRadius: 13))
+    }
+
+    /// One click for the whole thing where that's possible; the old "fetch the DMG and let the
+    /// user drag it across" wording where it isn't, so the button never promises a restart it
+    /// can't deliver.
+    private var updateActionButton: some View {
+        Button {
+            Task { await updateChecker.downloadAndInstall() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: updateChecker.canInstallInPlace ? "arrow.triangle.2.circlepath" : "arrow.down.to.line")
+                Text(updateChecker.canInstallInPlace ? "Update & Restart" : "Download")
+            }
+            .font(.system(size: 11.5, weight: .medium))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 5)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.razerGreen)
+        .controlSize(.small)
+    }
+
+    private func updateProgress(_ fraction: Double) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ProgressView(value: fraction)
+                .progressViewStyle(.linear)
+                .tint(.razerGreen)
+            Text("Downloading… \(Int(fraction * 100))%")
+                .font(.system(size: 10.5)).foregroundStyle(.secondary).monospacedDigit()
+        }
+    }
+
+    /// The update is on disk but the relaunch didn't take. Say so plainly and give the one
+    /// action that finishes it — not the error-and-retry treatment a failed install gets.
+    private var updateNeedsRestart: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Update installed. Quit and reopen MacRazer to use it.")
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Button("Quit MacRazer") { NSApplication.shared.terminate(nil) }
+                .buttonStyle(.borderedProminent)
+                .tint(.razerGreen)
+                .controlSize(.small)
+                .font(.system(size: 11.5, weight: .medium))
+        }
+    }
+
+    private func updateBusyLabel(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            ProgressView().controlSize(.small)
+            Text(text).font(.system(size: 11)).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: Battery hero
@@ -786,17 +842,54 @@ struct PopoverView: View {
 
     private var settingsCard: some View {
         card {
-            Toggle(isOn: Binding(
-                get: { controller.showPercentInMenuBar },
-                set: { controller.showPercentInMenuBar = $0 }
-            )) {
-                Text("Show battery % in menu bar")
-                    .font(.system(size: 12))
+            VStack(alignment: .leading, spacing: 9) {
+                if controller.deviceHasBattery {
+                    Toggle(isOn: Binding(
+                        get: { controller.showPercentInMenuBar },
+                        set: { controller.showPercentInMenuBar = $0 }
+                    )) {
+                        Text("Show battery % in menu bar")
+                            .font(.system(size: 12))
+                    }
+                }
+                launchAtLoginSetting
             }
             .toggleStyle(.switch)
             .tint(.razerGreen)
             .controlSize(.small)
         }
+    }
+
+    private var launchAtLoginSetting: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(isOn: Binding(
+                get: { launchAtLogin.isEnabled },
+                set: { launchAtLogin.setEnabled($0) }
+            )) {
+                Text("Start MacRazer at login")
+                    .font(.system(size: 12))
+            }
+            .disabled(!launchAtLogin.isSupported)
+            // Shown rather than hidden when unavailable: running straight from the disk image
+            // is a real thing people do, and "why is this switch dead" deserves an answer.
+            if !launchAtLogin.isSupported {
+                settingNote("Move MacRazer to your Applications folder to use this.")
+            } else if let error = launchAtLogin.lastError {
+                settingNote(error, color: .batteryLow)
+            } else if launchAtLogin.needsApproval {
+                Button("Approve MacRazer in Login Items…") { launchAtLogin.openLoginItemsSettings() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Color.razerGreen)
+            }
+        }
+    }
+
+    private func settingNote(_ text: String, color: Color = .secondary) -> some View {
+        Text(text)
+            .font(.system(size: 10.5))
+            .foregroundStyle(color)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: Footer
@@ -806,9 +899,26 @@ struct PopoverView: View {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "dev"
     }
 
+    /// The project page. A menu bar app has nowhere to put an "About", and the version line is
+    /// already what people look at to answer "what am I running" — so it doubles as the way
+    /// there, rather than adding another row to a popover that's long enough.
+    private static let websiteURL = URL(string: "https://sorcrr.github.io/MacRazer/")!
+
     private var footer: some View {
-        HStack {
-            Text(verbatim: "v\(appVersion) · unofficial").font(.system(size: 11)).foregroundStyle(.tertiary)
+        HStack(spacing: 4) {
+            Link(destination: Self.websiteURL) {
+                Text(verbatim: "v\(appVersion)")
+                    .font(.system(size: 11))
+                    // Nothing at rest marks it as a link — the footer should stay quiet — so
+                    // hover has to carry the whole affordance: colour and underline together,
+                    // since colour alone is easy to miss at 11pt in tertiary grey.
+                    .foregroundStyle(versionHovered ? AnyShapeStyle(Color.razerGreen) : AnyShapeStyle(.tertiary))
+                    .underline(versionHovered)
+            }
+            .buttonStyle(.plain)
+            .onHover { versionHovered = $0 }
+            .help("Open the MacRazer website")
+            Text(verbatim: "· unofficial").font(.system(size: 11)).foregroundStyle(.tertiary)
             Spacer()
             Button("Quit") { NSApplication.shared.terminate(nil) }
                 .buttonStyle(.borderless)

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -203,15 +203,30 @@ final class UpdateChecker: ObservableObject {
         }
     }
 
-    /// The manual-DMG path can't delete its own download — the user still has to open it —
-    /// so nothing ever cleaned those up and each one left several megabytes behind for good.
-    /// Sweeping at the start of the next download is the natural moment: by then every earlier
-    /// directory has served its purpose.
+    /// The manual-DMG path can't delete its own download — the user still has to open it — so
+    /// nothing ever cleaned those up and each one left several megabytes behind for good.
+    ///
+    /// Only directories older than `staleAfter` go, and that age limit is the whole point
+    /// rather than a tidiness detail: "everything earlier has served its purpose" is false for
+    /// the download we handed to Finder a minute ago. The user may not have opened it yet, or
+    /// may have it mounted — and deleting a mounted image's backing file leaves the volume
+    /// broken, which is worse than the leak this is fixing.
+    ///
+    /// An image still mounted from more than an hour ago is the residual case, and the
+    /// accepted trade: by then the user has either installed from it or forgotten it.
+    private static let staleAfter: TimeInterval = 60 * 60
+
     private static func sweepStaleDownloads() {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
         let entries = (try? FileManager.default.contentsOfDirectory(
-            at: tmp, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants])) ?? []
+            at: tmp, includingPropertiesForKeys: [.creationDateKey],
+            options: [.skipsSubdirectoryDescendants])) ?? []
+        let cutoff = Date().addingTimeInterval(-staleAfter)
         for entry in entries where entry.lastPathComponent.hasPrefix("MacRazerUpdate-") {
+            // No readable creation date: leave it alone. Erring towards a leak beats erring
+            // towards deleting a file someone is using.
+            guard let created = (try? entry.resourceValues(forKeys: [.creationDateKey]))?.creationDate,
+                  created < cutoff else { continue }
             try? FileManager.default.removeItem(at: entry)
         }
     }

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -76,11 +76,21 @@ final class UpdateChecker: ObservableObject {
     /// would be a no-op for exactly the people who dismissed the card and later changed their
     /// mind — the only ones who'd think to use it.
     func checkForUpdatesNow(userRequested: Bool = false) async {
-        if userRequested { UserDefaults.standard.removeObject(forKey: Self.dismissedKey) }
+        // Never while installing. A check that resolves to "nothing newer" clears
+        // `latestVersion`, and the popover's whole update card is mounted on that — so a
+        // background check landing mid-install would erase the progress bar out from under a
+        // swap-and-relaunch already in flight. There is also nothing to learn: we are already
+        // installing the newest thing we know about.
+        guard !isBusy else { return }
         do {
             let (data, _) = try await URLSession.shared.data(from: releaseAPIURL)
             let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
             let remote = release.tag_name.hasPrefix("v") ? String(release.tag_name.dropFirst()) : release.tag_name
+            // Only *now* drop a previous dismissal — after the check actually succeeded.
+            // Clearing it up front spent the user's decision even when the request then
+            // failed, and `restoreLastFound()` would resurrect the very version they had
+            // dismissed, having learned nothing.
+            if userRequested { UserDefaults.standard.removeObject(forKey: Self.dismissedKey) }
             // Only a *successful* check counts against the daily throttle: a failed one
             // (offline right after wake is common) should retry on the next opportunity,
             // not silence update notices for a day.
@@ -169,6 +179,7 @@ final class UpdateChecker: ObservableObject {
     /// Downloads into a fresh temp directory, so the caller can delete the whole thing without
     /// worrying about what else might be sharing a filename in `/tmp`.
     private func downloadDMG() async throws -> URL {
+        Self.sweepStaleDownloads()
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("MacRazerUpdate-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -189,6 +200,19 @@ final class UpdateChecker: ObservableObject {
             // with it — otherwise every offline retry leaves one behind.
             try? FileManager.default.removeItem(at: dir)
             throw error
+        }
+    }
+
+    /// The manual-DMG path can't delete its own download — the user still has to open it —
+    /// so nothing ever cleaned those up and each one left several megabytes behind for good.
+    /// Sweeping at the start of the next download is the natural moment: by then every earlier
+    /// directory has served its purpose.
+    private static func sweepStaleDownloads() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: tmp, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants])) ?? []
+        for entry in entries where entry.lastPathComponent.hasPrefix("MacRazerUpdate-") {
+            try? FileManager.default.removeItem(at: entry)
         }
     }
 
@@ -227,13 +251,15 @@ final class UpdateChecker: ObservableObject {
 /// `URLSession.download(from:)` reports no progress at all, so this is the delegate form
 /// wrapped back into async/await.
 ///
-/// `@unchecked Sendable` under a stated discipline: every mutable field is touched only on the
-/// session's own delegate queue, which is serial (`maxConcurrentOperationCount = 1`), except
-/// for the two assignments made inside the continuation closure before the task is resumed —
-/// i.e. before any callback can fire.
+/// `@unchecked Sendable`, made safe by an actual lock rather than by an argument about
+/// ordering: `continuation` and `session` are written by the caller and read on the session's
+/// delegate queue, so nothing in this code establishes visibility between the two threads on
+/// its own. `lock` does, and it also makes the resolve-exactly-once rule enforced rather than
+/// merely true — `didFinishDownloadingTo` and `didCompleteWithError` both fire on success.
 private final class ProgressDownload: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     private let destination: URL
     private let onProgress: @Sendable (Double) -> Void
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<URL, Error>?
     private var session: URLSession?
     /// Last reported whole percent — the callback fires far more often than a progress bar can
@@ -247,22 +273,28 @@ private final class ProgressDownload: NSObject, URLSessionDownloadDelegate, @unc
 
     func run(from url: URL) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
             let queue = OperationQueue()
-            queue.maxConcurrentOperationCount = 1 // serial: the state below has no lock
+            queue.maxConcurrentOperationCount = 1
             let session = URLSession(configuration: .ephemeral, delegate: self, delegateQueue: queue)
+            lock.lock()
+            self.continuation = continuation
             self.session = session
+            lock.unlock()
             session.downloadTask(with: url).resume()
         }
     }
 
-    /// Resolves once and once only — `didFinishDownloadingTo` and `didCompleteWithError` both
-    /// fire on a successful download.
+    /// Resolves once and once only.
     private func finish(_ result: Result<URL, Error>) {
-        guard let continuation else { return }
+        lock.lock()
+        guard let continuation else { lock.unlock(); return }
         self.continuation = nil
+        let session = self.session
+        self.session = nil
+        lock.unlock()
+        // Outside the lock: invalidation drains the delegate queue, and resuming hands control
+        // back to the awaiting task — neither belongs under a lock this narrow.
         session?.finishTasksAndInvalidate() // also breaks the session's retain on this delegate
-        session = nil
         continuation.resume(with: result)
     }
 

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -4,14 +4,33 @@
 import AppKit
 import Foundation
 
-/// Polls GitHub Releases once a day for a newer MacRazer version, and lets the user download
-/// and open the new DMG without leaving the app. No Sparkle/appcast — the app is unsigned and
-/// distributed as a plain DMG, so "update" just means "fetch the latest DMG and let the user
-/// drag it into Applications themselves," same as a manual download.
+/// Polls GitHub Releases once a day for a newer MacRazer version, and installs it.
+///
+/// No Sparkle/appcast — the app is unsigned-by-Apple and distributed as a plain DMG. When
+/// MacRazer is installed somewhere it can write to, "update" means the whole manual routine
+/// done for you: fetch the DMG, verify it, swap the bundle, relaunch (`UpdateInstaller`).
+/// Everywhere else — running from the image itself, a translocated copy, a folder the user
+/// can't write — it falls back to what this used to do: download the DMG and open it, so the
+/// user drags it across as before.
 @MainActor
 final class UpdateChecker: ObservableObject {
+    /// What the update card is doing right now. Drives a real progress bar: a multi-megabyte
+    /// download behind a bare spinner is indistinguishable from a hang.
+    enum Phase: Equatable {
+        case idle
+        case downloading(Double)
+        /// Mounting, checking and swapping the bundle — seconds, and not meaningfully
+        /// divisible into steps a user would care to watch.
+        case installing
+        case restarting
+        /// Installed, but the new instance wouldn't start — the user has to quit and reopen.
+        /// A terminal state, and deliberately not an error: offering the DMG again here would
+        /// invite reinstalling over an update that already succeeded.
+        case needsRestart
+    }
+
     @Published private(set) var latestVersion: String?
-    @Published private(set) var isDownloading = false
+    @Published private(set) var phase: Phase = .idle
     @Published var downloadError: String?
 
     private let releaseAPIURL = URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
@@ -30,6 +49,12 @@ final class UpdateChecker: ObservableObject {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0"
     }
 
+    var isBusy: Bool { phase != .idle }
+
+    /// Whether the one-click "Update & Restart" path is available, or the card should offer
+    /// the manual DMG instead.
+    var canInstallInPlace: Bool { UpdateInstaller.canInstallInPlace }
+
     /// Checks at most once per `checkInterval`, regardless of how often this is called — safe to
     /// call on every launch and from a repeating timer.
     func checkForUpdatesIfDue() async {
@@ -43,9 +68,15 @@ final class UpdateChecker: ObservableObject {
         await checkForUpdatesNow()
     }
 
-    /// Bypasses the throttle — used by `checkForUpdatesIfDue()` once due, and available for a
-    /// manual "Check Now" action.
-    func checkForUpdatesNow() async {
+    /// Bypasses the throttle — used by `checkForUpdatesIfDue()` once due, and by the menu's
+    /// "Check for Updates…".
+    ///
+    /// `userRequested` also drops a previous "dismiss": someone who goes looking for an update
+    /// wants the answer, not the silence they asked for last week. Without it the menu item
+    /// would be a no-op for exactly the people who dismissed the card and later changed their
+    /// mind — the only ones who'd think to use it.
+    func checkForUpdatesNow(userRequested: Bool = false) async {
+        if userRequested { UserDefaults.standard.removeObject(forKey: Self.dismissedKey) }
         do {
             let (data, _) = try await URLSession.shared.data(from: releaseAPIURL)
             let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
@@ -85,23 +116,188 @@ final class UpdateChecker: ObservableObject {
         latestVersion = nil
     }
 
-    func downloadAndOpenDMG() async {
-        guard !isDownloading else { return }
-        isDownloading = true
+    // MARK: - Installing
+
+    /// Download the new DMG, replace this app with the copy inside it, and relaunch into it.
+    /// Falls back to `downloadAndOpenDMG()` wherever an in-place swap isn't possible, so the
+    /// button always does *something* useful.
+    func downloadAndInstall() async {
+        guard !isBusy else { return }
+        guard let target = UpdateInstaller.installTarget, UpdateInstaller.canInstallInPlace else {
+            await downloadAndOpenDMG()
+            return
+        }
         downloadError = nil
-        defer { isDownloading = false }
+        phase = .downloading(0)
+        let bundleID = Bundle.main.bundleIdentifier
+        let current = currentVersion
         do {
-            let (tmpURL, _) = try await URLSession.shared.download(from: dmgURL)
-            let dest = tmpURL.deletingLastPathComponent().appendingPathComponent("MacRazer.dmg")
-            try? FileManager.default.removeItem(at: dest)
-            try FileManager.default.moveItem(at: tmpURL, to: dest)
-            NSWorkspace.shared.open(dest)
+            let dmg = try await downloadDMG()
+            defer { try? FileManager.default.removeItem(at: dmg.deletingLastPathComponent()) }
+            phase = .installing
+            // Off the main actor: mounting, verifying and copying a bundle would freeze the
+            // popover (and the menu bar) for the seconds it takes.
+            _ = try await Task.detached(priority: .userInitiated) {
+                try UpdateInstaller.installInPlace(
+                    dmg: dmg, into: target, expectedBundleID: bundleID, currentVersion: current)
+            }.value
+            phase = .restarting
+            relaunch(at: target)
         } catch {
+            phase = .idle
+            downloadError = (error as? LocalizedError)?.errorDescription
+                ?? "The update couldn't be installed. Try downloading it manually."
+        }
+    }
+
+    /// The fallback (and what this class used to do outright): fetch the DMG and open it, so
+    /// the user drags MacRazer across themselves.
+    func downloadAndOpenDMG() async {
+        guard !isBusy else { return }
+        downloadError = nil
+        phase = .downloading(0)
+        do {
+            let dmg = try await downloadDMG()
+            phase = .idle
+            NSWorkspace.shared.open(dmg)
+        } catch {
+            phase = .idle
             downloadError = "Download failed — check your connection and try again."
+        }
+    }
+
+    /// Downloads into a fresh temp directory, so the caller can delete the whole thing without
+    /// worrying about what else might be sharing a filename in `/tmp`.
+    private func downloadDMG() async throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("MacRazerUpdate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let downloader = ProgressDownload(
+            destination: dir.appendingPathComponent("MacRazer.dmg")
+        ) { [weak self] fraction in
+            Task { @MainActor in
+                // Only while still downloading: a late callback must not drag the card back
+                // out of "Installing…".
+                guard let self, case .downloading = self.phase else { return }
+                self.phase = .downloading(fraction)
+            }
+        }
+        do {
+            return try await downloader.run(from: dmgURL)
+        } catch {
+            // Nobody else knows about this directory yet, so a failed download has to take it
+            // with it — otherwise every offline retry leaves one behind.
+            try? FileManager.default.removeItem(at: dir)
+            throw error
+        }
+    }
+
+    /// Same shape as `PermissionsModel.relaunch()`, and for the same reason: only quit once the
+    /// replacement instance is actually up. The bundle on disk is already the new version, so a
+    /// failed open must leave the running (old) app alive rather than turn "Update" into
+    /// "Quit" — the user can relaunch by hand and get the new version.
+    private func relaunch(at url: URL) {
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: url, configuration: config) { app, error in
+            Task { @MainActor in
+                if app != nil, error == nil {
+                    NSApp.terminate(nil)
+                } else {
+                    self.phase = .needsRestart
+                }
+            }
         }
     }
 
     private static func isNewer(_ remote: String, than local: String) -> Bool {
         VersionCompare.isNewer(remote, than: local)
+    }
+
+    // MARK: - Preview
+
+    /// Pins the update card open for the `render-ui` preview, which otherwise only shows it on
+    /// the rare day a real release is newer than the running build.
+    func loadPreviewState(version: String = "9.9.9", phase: Phase = .idle) {
+        latestVersion = version
+        self.phase = phase
+    }
+}
+
+/// `URLSession.download(from:)` reports no progress at all, so this is the delegate form
+/// wrapped back into async/await.
+///
+/// `@unchecked Sendable` under a stated discipline: every mutable field is touched only on the
+/// session's own delegate queue, which is serial (`maxConcurrentOperationCount = 1`), except
+/// for the two assignments made inside the continuation closure before the task is resumed —
+/// i.e. before any callback can fire.
+private final class ProgressDownload: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let destination: URL
+    private let onProgress: @Sendable (Double) -> Void
+    private var continuation: CheckedContinuation<URL, Error>?
+    private var session: URLSession?
+    /// Last reported whole percent — the callback fires far more often than a progress bar can
+    /// show, and each report costs a hop to the main actor.
+    private var lastReportedPercent = -1
+
+    init(destination: URL, onProgress: @escaping @Sendable (Double) -> Void) {
+        self.destination = destination
+        self.onProgress = onProgress
+    }
+
+    func run(from url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            let queue = OperationQueue()
+            queue.maxConcurrentOperationCount = 1 // serial: the state below has no lock
+            let session = URLSession(configuration: .ephemeral, delegate: self, delegateQueue: queue)
+            self.session = session
+            session.downloadTask(with: url).resume()
+        }
+    }
+
+    /// Resolves once and once only — `didFinishDownloadingTo` and `didCompleteWithError` both
+    /// fire on a successful download.
+    private func finish(_ result: Result<URL, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        session?.finishTasksAndInvalidate() // also breaks the session's retain on this delegate
+        session = nil
+        continuation.resume(with: result)
+    }
+
+    func urlSession(
+        _ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData _: Int64,
+        totalBytesWritten written: Int64, totalBytesExpectedToWrite expected: Int64
+    ) {
+        guard expected > 0 else { return } // unknown length — leave the bar where it is
+        let fraction = min(1, Double(written) / Double(expected))
+        let percent = Int(fraction * 100)
+        guard percent != lastReportedPercent else { return }
+        lastReportedPercent = percent
+        onProgress(fraction)
+    }
+
+    func urlSession(
+        _ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL
+    ) {
+        // A 404 body would otherwise be moved into place and only fail later, at mount time,
+        // as the far less useful "the update couldn't be opened".
+        if let http = downloadTask.response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            finish(.failure(URLError(.badServerResponse)))
+            return
+        }
+        // The temp file is deleted the moment this returns, so the move has to happen here.
+        do {
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: location, to: destination)
+            finish(.success(destination))
+        } catch {
+            finish(.failure(error))
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error { finish(.failure(error)) }
     }
 }

--- a/Sources/MacRazer/UpdateInstaller.swift
+++ b/Sources/MacRazer/UpdateInstaller.swift
@@ -33,7 +33,6 @@ enum UpdatePayloadCheck {
 }
 
 enum UpdateInstallError: LocalizedError, Equatable {
-    case notInstalled
     case notWritable
     case mountFailed
     case noAppInImage
@@ -44,8 +43,6 @@ enum UpdateInstallError: LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
-        case .notInstalled:
-            return "Move MacRazer to your Applications folder first, then updates install themselves."
         case .notWritable:
             return "MacRazer can't write to its own folder — install the update manually."
         case .mountFailed:
@@ -131,15 +128,35 @@ enum UpdateInstaller {
         // faithfully (ACLs, xattrs, symlinks), and a copy that loses any of those loses the
         // code signature with them.
         let copy = run("/usr/bin/ditto", [payload.path, staged.path])
-        guard copy.status == 0 else { throw UpdateInstallError.copyFailed(copy.errorText) }
+        guard copy.status == 0 else {
+            throw log(.copyFailed(copy.errorText))
+        }
         stripQuarantine(from: staged)
+        // Verify the copy, not just the original. `ditto` can report success and still leave
+        // a bundle the seal no longer covers (a truncated write on a full disk, an xattr it
+        // declined to carry), and this is the last moment before a working app is unlinked.
+        try verifySignature(of: staged)
 
         do {
             _ = try FileManager.default.replaceItemAt(target, withItemAt: staged)
         } catch {
-            throw UpdateInstallError.swapFailed(error.localizedDescription)
+            throw log(.swapFailed(error.localizedDescription))
         }
         return version ?? currentVersion
+    }
+
+    /// Copy/swap failures depend on disk state, permissions and volume layout — the hardest
+    /// class to reproduce from a bug report, and the only one whose detail we actually capture.
+    /// The user-facing string stays short; the detail goes where the other subsystems put
+    /// theirs (`HIDMonitor`, `MenuBarIcon.writePreview`).
+    private static func log(_ error: UpdateInstallError) -> UpdateInstallError {
+        let detail: String
+        switch error {
+        case .copyFailed(let text), .swapFailed(let text): detail = text
+        default: detail = ""
+        }
+        FileHandle.standardError.write(Data("[MacRazer] update install failed: \(error) \(detail)\n".utf8))
+        return error
     }
 
     // MARK: - Disk image
@@ -230,10 +247,20 @@ enum UpdateInstaller {
         } catch {
             return ProcessResult(status: -1, output: Data(), errorText: error.localizedDescription)
         }
-        // Drain before waiting: hdiutil's plist is comfortably larger than a pipe buffer, and
-        // waiting first would deadlock against a child blocked on a full pipe.
+        // Both pipes have to be drained *concurrently*, and drained before waiting.
+        //
+        // Waiting first deadlocks against a child blocked on a full pipe — hdiutil's plist is
+        // comfortably larger than a pipe buffer. But draining one to EOF and only then the
+        // other deadlocks too, whenever the child fills the second pipe while we are still
+        // blocked on the first: a verbose hdiutil or ditto failure writing tens of KB to
+        // stderr is exactly that shape, and it would hang the install with no timeout.
+        nonisolated(unsafe) var errData = Data()
+        let group = DispatchGroup()
+        DispatchQueue.global(qos: .userInitiated).async(group: group) {
+            errData = err.fileHandleForReading.readDataToEndOfFile()
+        }
         let outData = out.fileHandleForReading.readDataToEndOfFile()
-        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        group.wait() // also the happens-before edge that makes errData safe to read here
         process.waitUntilExit()
         return ProcessResult(
             status: process.terminationStatus, output: outData,

--- a/Sources/MacRazer/UpdateInstaller.swift
+++ b/Sources/MacRazer/UpdateInstaller.swift
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+import Security
+
+/// The checks that decide whether the app inside a downloaded image may replace the running
+/// one. Pure — no filesystem, no subprocesses — so every refusal is unit-testable.
+///
+/// This is the part that must not be got wrong: `installInPlace` deletes the installed bundle,
+/// so anything that reaches the swap has to be a genuine, newer MacRazer.
+enum UpdatePayloadCheck {
+    enum Rejection: Equatable {
+        /// Not the app we're updating (or an unreadable Info.plist).
+        case wrongApp
+        /// Same version or older. Nothing to gain, and a real bundle to lose.
+        case notNewer(String)
+    }
+
+    static func reject(
+        payloadBundleID: String?, payloadVersion: String?,
+        expectedBundleID: String?, currentVersion: String
+    ) -> Rejection? {
+        // nil on either side is a refusal, never a match: a missing expectation must not
+        // wave through a missing identifier.
+        guard let expectedBundleID, let payloadBundleID, payloadBundleID == expectedBundleID,
+              let payloadVersion, !payloadVersion.isEmpty else { return .wrongApp }
+        guard VersionCompare.isNewer(payloadVersion, than: currentVersion) else {
+            return .notNewer(payloadVersion)
+        }
+        return nil
+    }
+}
+
+enum UpdateInstallError: LocalizedError, Equatable {
+    case notInstalled
+    case notWritable
+    case mountFailed
+    case noAppInImage
+    case rejected(UpdatePayloadCheck.Rejection)
+    case signatureInvalid
+    case copyFailed(String)
+    case swapFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notInstalled:
+            return "Move MacRazer to your Applications folder first, then updates install themselves."
+        case .notWritable:
+            return "MacRazer can't write to its own folder — install the update manually."
+        case .mountFailed:
+            return "The downloaded update couldn't be opened. Try again."
+        case .noAppInImage, .rejected(.wrongApp):
+            return "The downloaded update didn't contain a MacRazer app. Try again."
+        case .rejected(.notNewer(let version)):
+            return "The download was version \(version), which isn't newer than what you're running."
+        case .signatureInvalid:
+            return "The downloaded update failed its signature check — it may be damaged."
+        case .copyFailed, .swapFailed:
+            return "The update downloaded but couldn't be installed. Install it manually instead."
+        }
+    }
+}
+
+/// Replaces the installed `MacRazer.app` with the one inside a downloaded DMG.
+///
+/// No Sparkle here: the app is self-signed and shipped as a plain drag-to-install image, so
+/// there is no appcast and no EdDSA key to check a payload against. What this does instead is
+/// precisely the manual install, automated — mount the image, confirm the app inside really is
+/// a newer MacRazer whose signature is intact, then swap it into place atomically. The caller
+/// relaunches.
+///
+/// Replacing a *running* bundle is safe because nothing is overwritten in place:
+/// `replaceItemAt` moves the old bundle aside and unlinks it, and a running process keeps its
+/// mapped executable alive through the unlink. The new copy only takes effect on relaunch,
+/// which is the next thing that happens.
+///
+/// Swapping *in place* — same path, same signing identity — is also what keeps the two things
+/// macOS has recorded against this app pointing at it: the Input Monitoring grant, without
+/// which MacRazer can't read the mouse at all, and the `SMAppService` login item registered by
+/// `LaunchAtLogin`. Installing to a new path would silently cost the user both.
+enum UpdateInstaller {
+    /// Where an in-place update would write, or nil when there is nothing installed to
+    /// replace: `swift run`, a translocated copy, or the app running straight off the mounted
+    /// DMG — the last of which is exactly the case where "drag me to Applications" is still
+    /// the right answer.
+    static var installTarget: URL? { AppLocation.installedBundleURL }
+
+    /// Whether the one-click path is available at all. `/Applications` is group-writable by
+    /// admin users; a standard user (or an app sitting in someone else's home) isn't, and is
+    /// better sent to the DMG up front than failed halfway through.
+    static var canInstallInPlace: Bool {
+        guard let target = installTarget else { return false }
+        let fm = FileManager.default
+        return fm.isWritableFile(atPath: target.path)
+            && fm.isWritableFile(atPath: target.deletingLastPathComponent().path)
+    }
+
+    /// Mount → verify → swap. Blocking (subprocesses and a bundle copy); call it off the main
+    /// thread. Returns the version now installed.
+    @discardableResult
+    static func installInPlace(
+        dmg: URL, into target: URL, expectedBundleID: String?, currentVersion: String
+    ) throws -> String {
+        guard FileManager.default.isWritableFile(atPath: target.path) else {
+            throw UpdateInstallError.notWritable
+        }
+
+        let mount = try attach(dmg)
+        defer { detach(mount) }
+
+        guard let payload = appBundle(atRootOf: mount) else { throw UpdateInstallError.noAppInImage }
+        let info = NSDictionary(contentsOf: payload.appendingPathComponent("Contents/Info.plist"))
+        let version = info?["CFBundleShortVersionString"] as? String
+        if let rejection = UpdatePayloadCheck.reject(
+            payloadBundleID: info?["CFBundleIdentifier"] as? String, payloadVersion: version,
+            expectedBundleID: expectedBundleID, currentVersion: currentVersion
+        ) {
+            throw UpdateInstallError.rejected(rejection)
+        }
+        try verifySignature(of: payload)
+
+        // A replacement directory is guaranteed to be on the target's own volume, which is what
+        // makes the final swap a rename rather than a slow, interruptible cross-volume copy.
+        let staging = try FileManager.default.url(
+            for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: target, create: true)
+        defer { try? FileManager.default.removeItem(at: staging) }
+        let staged = staging.appendingPathComponent(target.lastPathComponent)
+
+        // ditto rather than FileManager.copyItem: it is the tool that copies app bundles
+        // faithfully (ACLs, xattrs, symlinks), and a copy that loses any of those loses the
+        // code signature with them.
+        let copy = run("/usr/bin/ditto", [payload.path, staged.path])
+        guard copy.status == 0 else { throw UpdateInstallError.copyFailed(copy.errorText) }
+        stripQuarantine(from: staged)
+
+        do {
+            _ = try FileManager.default.replaceItemAt(target, withItemAt: staged)
+        } catch {
+            throw UpdateInstallError.swapFailed(error.localizedDescription)
+        }
+        return version ?? currentVersion
+    }
+
+    // MARK: - Disk image
+
+    private static func attach(_ dmg: URL) throws -> URL {
+        // Checksum verification is deliberately left on (no `-noverify`): it is the cheapest
+        // way to catch a truncated or corrupted download before anything is replaced.
+        let result = run("/usr/bin/hdiutil", ["attach", dmg.path, "-nobrowse", "-readonly", "-plist"])
+        guard result.status == 0,
+              let plist = try? PropertyListSerialization.propertyList(
+                  from: result.output, options: [], format: nil) as? [String: Any],
+              let entities = plist["system-entities"] as? [[String: Any]],
+              // Several entities are listed (the whole-disk one has no mount point); the one
+              // we want is the first that actually mounted.
+              let mount = entities.compactMap({ $0["mount-point"] as? String })
+                  .first(where: { !$0.isEmpty })
+        else { throw UpdateInstallError.mountFailed }
+        return URL(fileURLWithPath: mount)
+    }
+
+    private static func detach(_ mount: URL) {
+        guard run("/usr/bin/hdiutil", ["detach", mount.path, "-quiet"]).status != 0 else { return }
+        // Something (Spotlight, Finder, the copy we just made) is still holding the volume.
+        // Force it rather than leaving a phantom disk mounted for the rest of the session.
+        _ = run("/usr/bin/hdiutil", ["detach", mount.path, "-force", "-quiet"])
+    }
+
+    /// The single `.app` at the image's root. Matched by extension, not by name, so a renamed
+    /// release asset still installs — the identity checks are the Info.plist's job.
+    private static func appBundle(atRootOf mount: URL) -> URL? {
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: mount, includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])) ?? []
+        return entries.first { $0.pathExtension == "app" }
+    }
+
+    // MARK: - Integrity
+
+    /// Seal integrity, *not* trust: MacRazer is self-signed, so a Gatekeeper assessment
+    /// (`spctl --assess`) would reject every legitimate release. What matters here is that the
+    /// bundle about to replace a working app is byte-for-byte what was signed.
+    ///
+    /// The signing *identity* is deliberately not compared against the running app's. It would
+    /// catch nothing an HTTPS fetch from the project's own releases doesn't already cover, and
+    /// it would brick updates for every existing user the day the maintainer's self-signed
+    /// certificate is regenerated. The cost of an identity change is a re-prompt for Input
+    /// Monitoring, which is recoverable; a stuck updater isn't.
+    private static func verifySignature(of app: URL) throws {
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(app as CFURL, [], &code) == errSecSuccess,
+              let code,
+              SecStaticCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSCheckAllArchitectures), nil)
+                  == errSecSuccess
+        else { throw UpdateInstallError.signatureInvalid }
+    }
+
+    /// Best-effort: a quarantined replacement would make macOS re-run Gatekeeper on a
+    /// self-signed app, i.e. greet the user with the scary first-launch dialog after an update
+    /// they didn't even have to click through. Nothing here downloads via LaunchServices, so
+    /// the attribute normally isn't set at all — this is belt and braces.
+    private static func stripQuarantine(from bundle: URL) {
+        let name = "com.apple.quarantine"
+        removexattr(bundle.path, name, XATTR_NOFOLLOW)
+        guard let walker = FileManager.default.enumerator(
+            at: bundle, includingPropertiesForKeys: nil, options: []) else { return }
+        for case let url as URL in walker {
+            removexattr(url.path, name, XATTR_NOFOLLOW)
+        }
+    }
+
+    // MARK: - Subprocess
+
+    private struct ProcessResult {
+        let status: Int32
+        let output: Data
+        let errorText: String
+    }
+
+    private static func run(_ tool: String, _ arguments: [String]) -> ProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tool)
+        process.arguments = arguments
+        let out = Pipe(), err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        do {
+            try process.run()
+        } catch {
+            return ProcessResult(status: -1, output: Data(), errorText: error.localizedDescription)
+        }
+        // Drain before waiting: hdiutil's plist is comfortably larger than a pipe buffer, and
+        // waiting first would deadlock against a child blocked on a full pipe.
+        let outData = out.fileHandleForReading.readDataToEndOfFile()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return ProcessResult(
+            status: process.terminationStatus, output: outData,
+            errorText: String(data: errData, encoding: .utf8) ?? "")
+    }
+}

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -159,7 +159,7 @@ case "icon":
     // Render the menu bar mark to a PNG for visual inspection.
     // Flags and the optional size are bare words, so they must be excluded from the
     // positional path — otherwise `icon charging` writes a file literally named "charging".
-    let iconFlags: Set<String> = ["charging", "nologo"]
+    let iconFlags: Set<String> = ["charging", "nologo", "light"]
     let iconArgs = args.dropFirst()
     let path = iconArgs.first { !iconFlags.contains($0) && Int($0) == nil } ?? "icon-preview.png"
     // Optional size, so the mark can be checked at real menu bar scale (~21pt @2x) rather
@@ -169,7 +169,8 @@ case "icon":
     // `nologo` matches the menu bar's own call (razerCutout: false) so what's previewed is
     // what ships there.
     guard MenuBarIcon.writePreview(to: path, size: size, razerCutout: !iconArgs.contains("nologo"),
-                                   charging: iconArgs.contains("charging")) else {
+                                   charging: iconArgs.contains("charging"),
+                                   lightMenuBar: iconArgs.contains("light")) else {
         print("Render failed")
         exit(1)
     }

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -10,6 +10,7 @@ import Foundation
 // openrazer/openrazer#2583.
 
 import AppKit
+import ServiceManagement
 import SwiftUI
 
 let args = Array(CommandLine.arguments.dropFirst())
@@ -85,6 +86,37 @@ case "info":
         print("  [\(i)] \(HIDDevice.describe(dev))")
     }
 
+case "login-item":
+    // Report on (and optionally flip) the "Start MacRazer at login" registration — the one
+    // piece of app state that lives in the system rather than in our own defaults, so it can't
+    // be checked by reading a file. `on`/`off` drive the same `LaunchAtLogin.setEnabled` the
+    // popover switch calls, which also makes this the repair path when the GUI isn't reachable.
+    // Only meaningful from the packaged .app: under `swift run` there is no bundle to register.
+    let loginItem = LaunchAtLogin()
+    if let arg = args.dropFirst().first {
+        switch arg {
+        case "on": loginItem.setEnabled(true)
+        case "off": loginItem.setEnabled(false)
+        default:
+            print("Usage: login-item [on|off]")
+            exit(64)
+        }
+        if let failure = loginItem.lastError { print("⚠︎ \(failure)") }
+    }
+    print("Bundle:   \(Bundle.main.bundleURL.path)")
+    print("Eligible: \(loginItem.isSupported ? "yes" : "no — not an installed .app (see AppLocation)")")
+    let status = SMAppService.mainApp.status
+    let described: String
+    switch status {
+    case .enabled: described = "enabled — macOS will start MacRazer at login"
+    case .notRegistered: described = "not registered — the switch is off"
+    case .requiresApproval: described = "requires approval in System Settings › General › Login Items"
+    case .notFound: described = "not found — macOS has no record of this bundle"
+    @unknown default: described = "unknown (raw \(status.rawValue))"
+    }
+    print("Status:   \(described)")
+    print("Default applied once: \(UserDefaults.standard.bool(forKey: "launchAtLoginDefaultApplied"))")
+
 case "render-ui":
     // Render the popover to a PNG for static visual inspection (no device needed).
     _ = NSApplication.shared
@@ -93,13 +125,18 @@ case "render-ui":
     controller.loadPreviewState()
     if args.contains("offline") { controller.setPreviewOffline() }
     if args.contains("bluetooth") { controller.setPreviewBluetooth() }
+    let updateChecker = UpdateChecker()
+    if args.contains("update") { updateChecker.loadPreviewState() }
+    if args.contains("downloading") { updateChecker.loadPreviewState(phase: .downloading(0.42)) }
+    let launchAtLogin = LaunchAtLogin()
+    launchAtLogin.loadPreviewState()
     let rootView: AnyView = args.contains("color")
         ? AnyView(ColorPickerPage(color: .constant(.blue), onBack: {}, onApply: { _ in }))
         : args.contains("usage")
         ? AnyView(UsageGraphView(controller: controller, onBack: {}))
         : args.contains("profiles")
         ? AnyView(ProfilesView(controller: controller, remapper: ButtonRemapper(), onBack: {}))
-        : AnyView(PopoverView(controller: controller, remapper: ButtonRemapper(), updateChecker: UpdateChecker()))
+        : AnyView(PopoverView(controller: controller, remapper: ButtonRemapper(), updateChecker: updateChecker, launchAtLogin: launchAtLogin))
     writeViewPNG(rootView, to: path)
 
 case "render-remap":
@@ -366,6 +403,6 @@ case "rgb":
 
 default:
     print("Unknown command: \(command)")
-    print("Available: info, battery, dpi [x] [y], poll [hz], stages [d1,d2,…] [active], rgb <static rrggbb|spectrum|wave|off>, brightness [pct]")
+    print("Available: info, battery, dpi [x] [y], poll [hz], stages [d1,d2,…] [active], rgb <static rrggbb|spectrum|wave|off>, brightness [pct], login-item [on|off]")
     exit(64)
 }

--- a/Tests/MacRazerTests/UpdateAndLaunchTests.swift
+++ b/Tests/MacRazerTests/UpdateAndLaunchTests.swift
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+final class AppLocationTests: XCTestCase {
+    func testInstalledAppBundlesAreStable() {
+        XCTAssertTrue(AppLocation.isStableInstall("/Applications/MacRazer.app"))
+        XCTAssertTrue(AppLocation.isStableInstall("/Users/me/Applications/MacRazer.app"))
+        XCTAssertTrue(AppLocation.isStableInstall("/Applications/MacRazer.app/"), "trailing slash")
+    }
+
+    func testRunningFromTheDiskImageIsNotAnInstall() {
+        // The commonest case by far: launched straight out of the mounted DMG, never dragged
+        // across. A login item recorded there points at nothing once the image is ejected.
+        XCTAssertFalse(AppLocation.isStableInstall("/Volumes/MacRazer/MacRazer.app"))
+    }
+
+    func testTranslocatedAndTemporaryCopiesAreNotInstalls() {
+        XCTAssertFalse(AppLocation.isStableInstall(
+            "/private/var/folders/x1/T/AppTranslocation/AB-CD/d/MacRazer.app"))
+        XCTAssertFalse(AppLocation.isStableInstall("/private/var/folders/x1/T/staging/MacRazer.app"))
+        XCTAssertFalse(AppLocation.isStableInstall("/tmp/MacRazer.app"))
+    }
+
+    func testNonBundlePathsAreNotInstalls() {
+        // `swift run`: Bundle.main is the SwiftPM binary's directory, not an .app.
+        XCTAssertFalse(AppLocation.isStableInstall("/Users/me/proj/.build/release"))
+        XCTAssertFalse(AppLocation.isStableInstall("/Applications/MacRazer.app/Contents/MacOS/MacRazer"))
+        XCTAssertFalse(AppLocation.isStableInstall("MacRazer.app"), "relative path")
+        XCTAssertFalse(AppLocation.isStableInstall(""))
+    }
+}
+
+final class UpdatePayloadCheckTests: XCTestCase {
+    private let id = "com.macrazer.menubar"
+
+    private func reject(_ bundleID: String?, _ version: String?, current: String = "0.2.1")
+        -> UpdatePayloadCheck.Rejection? {
+        UpdatePayloadCheck.reject(
+            payloadBundleID: bundleID, payloadVersion: version,
+            expectedBundleID: id, currentVersion: current)
+    }
+
+    func testAcceptsANewerBuildOfTheSameApp() {
+        XCTAssertNil(reject(id, "0.2.2"))
+        XCTAssertNil(reject(id, "0.3.0"))
+        XCTAssertNil(reject(id, "1.0.0"))
+    }
+
+    func testRejectsADifferentApp() {
+        // The swap deletes the installed bundle, so anything that isn't demonstrably MacRazer
+        // has to be refused — a mis-attached release asset must not overwrite the app.
+        XCTAssertEqual(reject("com.example.other", "9.9.9"), .wrongApp)
+    }
+
+    func testRejectsAnUnreadablePayload() {
+        // A missing Info.plist reads as nils; none of them may be waved through.
+        XCTAssertEqual(reject(nil, nil), .wrongApp)
+        XCTAssertEqual(reject(id, nil), .wrongApp)
+        XCTAssertEqual(reject(id, ""), .wrongApp)
+        XCTAssertEqual(
+            UpdatePayloadCheck.reject(
+                payloadBundleID: nil, payloadVersion: "0.3.0",
+                expectedBundleID: nil, currentVersion: "0.2.1"),
+            .wrongApp,
+            "two unknowns must not match each other")
+    }
+
+    func testRejectsSameOrOlderVersions() {
+        XCTAssertEqual(reject(id, "0.2.1"), .notNewer("0.2.1"))
+        XCTAssertEqual(reject(id, "0.2.0"), .notNewer("0.2.0"))
+        XCTAssertEqual(reject(id, "0.1.9"), .notNewer("0.1.9"))
+    }
+
+    func testVersionOrderingMatchesTheUpdateNotice() {
+        // Same comparator as the "update available" badge, so the card can't offer an update
+        // the installer then refuses.
+        XCTAssertNil(reject(id, "0.2.10", current: "0.2.9"))
+        XCTAssertEqual(reject(id, "0.2.9", current: "0.2.10"), .notNewer("0.2.9"))
+    }
+}

--- a/Tests/MacRazerTests/UpdateAndLaunchTests.swift
+++ b/Tests/MacRazerTests/UpdateAndLaunchTests.swift
@@ -11,10 +11,14 @@ final class AppLocationTests: XCTestCase {
         XCTAssertTrue(AppLocation.isStableInstall("/Applications/MacRazer.app/"), "trailing slash")
     }
 
-    func testRunningFromTheDiskImageIsNotAnInstall() {
-        // The commonest case by far: launched straight out of the mounted DMG, never dragged
-        // across. A login item recorded there points at nothing once the image is ejected.
-        XCTAssertFalse(AppLocation.isStableInstall("/Volumes/MacRazer/MacRazer.app"))
+    func testAppsOnOtherVolumesAreStableByPath() {
+        // /Volumes/ used to be rejected outright to catch a mounted DMG, which also caught
+        // every external drive and secondary volume people keep applications on — and told
+        // them to move MacRazer to an Applications folder it was already in. A mounted image
+        // is now separated from a disk by being read-only, which `installedBundleURL` checks
+        // against the live filesystem; the path shape alone can't tell them apart.
+        XCTAssertTrue(AppLocation.isStableInstall("/Volumes/Media/Applications/MacRazer.app"))
+        XCTAssertTrue(AppLocation.isStableInstall("/Volumes/MacRazer/MacRazer.app"))
     }
 
     func testTranslocatedAndTemporaryCopiesAreNotInstalls() {

--- a/Tests/MacRazerTests/UpdateInstallerTests.swift
+++ b/Tests/MacRazerTests/UpdateInstallerTests.swift
@@ -30,8 +30,12 @@ final class UpdateInstallerTests: XCTestCase {
         // the rest of the run, and every later `hdiutil create -volname MacRazerTest` would
         // then mount as "MacRazerTest 1". `appBundle(atRootOf:)` still resolves that, so the
         // damage would surface as confusing passes rather than an honest error.
-        if FileManager.default.fileExists(atPath: "/Volumes/MacRazerTest") {
-            shell("/usr/bin/hdiutil", ["detach", "/Volumes/MacRazerTest", "-force", "-quiet"])
+        // Every MacRazerTest* volume, not just the unsuffixed one: a leak makes the *next*
+        // image mount as "MacRazerTest 1", so cleaning only the plain name recovers the first
+        // leak and lets the cascade it causes run for the rest of the suite.
+        for volume in (try? FileManager.default.contentsOfDirectory(atPath: "/Volumes")) ?? []
+        where volume.hasPrefix("MacRazerTest") {
+            shell("/usr/bin/hdiutil", ["detach", "/Volumes/\(volume)", "-force", "-quiet"])
         }
         if let root { try? FileManager.default.removeItem(at: root) }
         try super.tearDownWithError()

--- a/Tests/MacRazerTests/UpdateInstallerTests.swift
+++ b/Tests/MacRazerTests/UpdateInstallerTests.swift
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+/// End-to-end cover for `UpdateInstaller.installInPlace` against real disk images.
+///
+/// Heavier than the rest of the suite — it builds app bundles, ad-hoc signs them and wraps
+/// them in DMGs — and deliberately so: this is the one code path that *deletes the user's
+/// installed application*, and its safety rests entirely on refusals that a pure unit test of
+/// `UpdatePayloadCheck` cannot exercise. Every case below asserts the same thing after a
+/// refusal: the installed bundle is still there, still the old version.
+///
+/// Needs only base-system tools (`codesign`, `hdiutil`, `ditto`), so it runs in CI.
+final class UpdateInstallerTests: XCTestCase {
+    private var root: URL!
+    private let bundleID = "com.macrazer.test"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("MacRazerInstallerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let root { try? FileManager.default.removeItem(at: root) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Fixtures
+
+    /// A minimal but genuinely signed `.app`: the signature check is one of the things under
+    /// test, so the fixture has to carry a real seal, not a plausible-looking directory.
+    private func makeApp(named name: String, version: String, bundleID: String) throws -> URL {
+        let app = root.appendingPathComponent("\(name)/MacRazer.app", isDirectory: true)
+        let macOS = app.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "CFBundleIdentifier": bundleID,
+            "CFBundleShortVersionString": version,
+            "CFBundleExecutable": "MacRazer",
+            "CFBundlePackageType": "APPL",
+        ]
+        try (plist as NSDictionary).write(to: app.appendingPathComponent("Contents/Info.plist"))
+        // A real Mach-O is required — codesign refuses to seal a bundle whose executable
+        // isn't one. /bin/echo is tiny and always present.
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/echo"),
+                                         to: macOS.appendingPathComponent("MacRazer"))
+        XCTAssertEqual(shell("/usr/bin/codesign", ["--force", "--sign", "-", app.path]), 0,
+                       "fixture must be signed for the seal check to mean anything")
+        return app
+    }
+
+    /// `UDRW` by default purely for speed — it builds in ~3s against ~11s for the compressed
+    /// `UDZO` that releases actually ship, and these tests are about the install logic, not the
+    /// image format. The happy path passes `format: "UDZO"` so the real shape is still covered
+    /// end to end, checksum verification included.
+    private func makeDMG(containing app: URL, named name: String, format: String = "UDRW") throws -> URL {
+        let stage = root.appendingPathComponent("stage-\(name)", isDirectory: true)
+        try FileManager.default.createDirectory(at: stage, withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: app, to: stage.appendingPathComponent("MacRazer.app"))
+        return try makeDMG(fromFolder: stage, named: name, format: format)
+    }
+
+    private func makeDMG(fromFolder folder: URL, named name: String, format: String = "UDRW") throws -> URL {
+        let dmg = root.appendingPathComponent("\(name).dmg")
+        XCTAssertEqual(shell("/usr/bin/hdiutil", [
+            "create", "-volname", "MacRazerTest", "-srcfolder", folder.path,
+            "-ov", "-format", format, "-quiet", dmg.path,
+        ]), 0)
+        return dmg
+    }
+
+    @discardableResult
+    private func shell(_ tool: String, _ args: [String]) -> Int32 {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: tool)
+        p.arguments = args
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try? p.run()
+        p.waitUntilExit()
+        return p.terminationStatus
+    }
+
+    private func version(of app: URL) -> String? {
+        NSDictionary(contentsOf: app.appendingPathComponent("Contents/Info.plist"))?
+            .value(forKey: "CFBundleShortVersionString") as? String
+    }
+
+    private func install(_ dmg: URL, into target: URL, expecting bundleID: String? = nil,
+                         current: String = "1.0.0") throws -> String {
+        try UpdateInstaller.installInPlace(
+            dmg: dmg, into: target,
+            expectedBundleID: bundleID ?? self.bundleID, currentVersion: current)
+    }
+
+    // MARK: - The happy path
+
+    func testReplacesTheInstalledBundleWithTheNewerOne() throws {
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let dmg = try makeDMG(containing: try makeApp(named: "new", version: "2.0.0", bundleID: bundleID),
+                              named: "newer", format: "UDZO") // the format releases actually ship
+
+        let reported = try install(dmg, into: installed)
+
+        XCTAssertEqual(reported, "2.0.0")
+        XCTAssertEqual(version(of: installed), "2.0.0", "the bundle on disk was actually swapped")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: installed.appendingPathComponent("Contents/MacOS/MacRazer").path))
+        XCTAssertEqual(shell("/usr/bin/codesign", ["--verify", "--strict", installed.path]), 0,
+                       "the replacement must still be a sealed bundle macOS will run")
+        // A leaked mount would accumulate a phantom disk per update for the rest of the session.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: "/Volumes/MacRazerTest"))
+    }
+
+    // MARK: - Refusals: each must leave the installed app untouched
+
+    func testRefusesAnOlderPayload() throws {
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let dmg = try makeDMG(containing: try makeApp(named: "old", version: "0.9.0", bundleID: bundleID),
+                              named: "older")
+        XCTAssertThrowsError(try install(dmg, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .rejected(.notNewer("0.9.0")))
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+
+    func testRefusesTheSameVersion() throws {
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let dmg = try makeDMG(containing: try makeApp(named: "same", version: "1.0.0", bundleID: bundleID),
+                              named: "same")
+        XCTAssertThrowsError(try install(dmg, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .rejected(.notNewer("1.0.0")))
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+
+    func testRefusesADifferentApp() throws {
+        // A mis-attached release asset must not overwrite MacRazer with something else.
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let dmg = try makeDMG(
+            containing: try makeApp(named: "other", version: "9.9.9", bundleID: "com.example.other"),
+            named: "other")
+        XCTAssertThrowsError(try install(dmg, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .rejected(.wrongApp))
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+
+    func testRefusesATamperedPayload() throws {
+        // What a corrupted-but-mountable download looks like: the bundle changed after it was
+        // signed, so the seal no longer covers it.
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let payload = try makeApp(named: "tampered", version: "2.0.0", bundleID: bundleID)
+        let exe = payload.appendingPathComponent("Contents/MacOS/MacRazer")
+        // Overwrite *inside* the executable, not past the end of it. Bytes appended after the
+        // signature superblob fall outside the range the seal covers, so they validate fine —
+        // which is the failure mode a first draft of this test walked straight into.
+        let size = (try FileManager.default.attributesOfItem(atPath: exe.path)[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(size, 8192, "fixture executable is too small to corrupt meaningfully")
+        let handle = try FileHandle(forWritingTo: exe)
+        try handle.seek(toOffset: UInt64(size / 2))
+        handle.write(Data(repeating: 0x41, count: 256))
+        try handle.close()
+        let dmg = try makeDMG(containing: payload, named: "tampered")
+
+        XCTAssertThrowsError(try install(dmg, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .signatureInvalid)
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+
+    func testRefusesAnUnmountableImage() throws {
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let junk = root.appendingPathComponent("corrupt.dmg")
+        try Data((0..<200_000).map { _ in UInt8.random(in: 0...255) }).write(to: junk)
+        XCTAssertThrowsError(try install(junk, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .mountFailed)
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+
+    func testRefusesAnImageWithNoAppInIt() throws {
+        let installed = try makeApp(named: "installed", version: "1.0.0", bundleID: bundleID)
+        let stage = root.appendingPathComponent("empty-stage", isDirectory: true)
+        try FileManager.default.createDirectory(at: stage, withIntermediateDirectories: true)
+        try Data("not an app".utf8).write(to: stage.appendingPathComponent("README.txt"))
+        let dmg = try makeDMG(fromFolder: stage, named: "empty")
+
+        XCTAssertThrowsError(try install(dmg, into: installed)) {
+            XCTAssertEqual($0 as? UpdateInstallError, .noAppInImage)
+        }
+        XCTAssertEqual(version(of: installed), "1.0.0")
+    }
+}

--- a/Tests/MacRazerTests/UpdateInstallerTests.swift
+++ b/Tests/MacRazerTests/UpdateInstallerTests.swift
@@ -25,6 +25,14 @@ final class UpdateInstallerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        // `installInPlace` detaches in a `defer`, so the normal paths clean up after
+        // themselves — but a failure hard enough to skip it would leave the volume mounted for
+        // the rest of the run, and every later `hdiutil create -volname MacRazerTest` would
+        // then mount as "MacRazerTest 1". `appBundle(atRootOf:)` still resolves that, so the
+        // damage would surface as confusing passes rather than an honest error.
+        if FileManager.default.fileExists(atPath: "/Volumes/MacRazerTest") {
+            shell("/usr/bin/hdiutil", ["detach", "/Volumes/MacRazerTest", "-force", "-quiet"])
+        }
         if let root { try? FileManager.default.removeItem(at: root) }
         try super.tearDownWithError()
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -247,7 +247,10 @@
         <span class="step-num">3</span>
         <div>
           <p>Launch it. Grant <strong>Input Monitoring</strong> (and <strong>Accessibility</strong>
-          if you use button remapping) when asked.</p>
+          if you use button remapping) when asked. From then on MacRazer starts at login by
+          itself, and new versions install themselves — <strong>Update &amp; Restart</strong> in
+          the popover replaces the app and relaunches it, no dragging a DMG. Both are
+          switchable.</p>
         </div>
       </li>
     </ol>


### PR DESCRIPTION
Two gaps that both amounted to *the app quietly stops being there*.

## Start at login — on by default

`SMAppService.mainApp`, with a switch in the popover's settings card.

- The default is applied **exactly once** (first launch of a build that has it). After that the user's choice is the record — turning it off in the popover *or* in System Settings › General › Login Items is never undone by a later launch.
- The switch reads the **system's** registration rather than a preference of its own, and re-reads it on `applicationDidBecomeActive`, so it can't disagree with System Settings.
- Disabled, with an explanation, when running from the mounted DMG, a translocated copy, or `swift run` — a login item recorded at any of those paths points at nothing after a reboot. That rule lives in `AppLocation` and is unit-tested.

## Update & Restart

The update card now installs the update instead of handing you a DMG to drag: download with real progress → mount → verify → atomic swap → relaunch.

- The payload must be the same bundle ID, a newer version, and pass a `SecStaticCodeCheckValidity` seal check; `hdiutil` checksum verification catches a corrupt download first.
- **Nothing is deleted until a verified replacement is staged**, so a refused or failed install leaves the working app exactly where it was.
- The swap is **in place** — same path, same signing identity — which is what keeps the Input Monitoring grant *and* the login item pointing at the app.
- Falls back to the old download-the-DMG behaviour wherever an in-place swap isn't possible, and offers it as a second chance if an install fails. A successful install whose relaunch fails gets its own terminal state ("Quit and reopen"), not a red error plus a reinstall button.

## Also

- **"Check for Updates…"** in the right-click menu — it clears a previous dismissal, since someone who goes looking wants the answer.
- **`login-item [on|off]`** CLI diagnostic. The registration is the one piece of app state that lives in the system rather than in MacRazer's defaults, so it can't be checked by reading a file; `on`/`off` drive the same code the switch does, which makes it the repair path when the menu bar item isn't reachable.
- The **footer version is now a link** to the project page. A menu bar app has nowhere to put an "About", and that line is already where people look to answer "what am I running".

## Verification

`swift build` clean, 87 tests pass (9 new, covering `AppLocation` and the payload checks).

**Login item**, against a real `/Applications` install:

| step | status |
|---|---|
| installed, before first GUI launch | `not found`, default not applied |
| after first GUI launch | **`enabled`**, default applied |
| `login-item off` | `not registered` |
| full GUI relaunch after that | **still `not registered`** — the default does not undo the choice |
| `login-item on` | `enabled` |

**Installer**, driven end-to-end against real disk images (throwaway tests, not committed):

- happy path swaps the bundle to the new version and leaves a signature that passes `codesign --verify --strict`
- older payload, wrong bundle ID, corrupt image, and an app tampered with *after* signing are all refused with the installed bundle untouched
- no volume left mounted afterwards

Both the new build and the existing install sign under the same `MacRazer Self-Signed` authority, which is the assumption the in-place swap rests on.
