### PR TITLE
Add an About window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Added
-- **An About window** (menu bar right-click › About MacRazer). Version and build, the
+- **An About window**, first in the menu bar's right-click menu, where macOS puts About. Version and build, the
  developer, and the three things this app actually owes the person reading it: that it is
  **not affiliated with Razer Inc.** and uses their marks only to describe compatibility; that
  the device protocol was **ported from OpenRazer** — whose reverse-engineering this is built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Added
+- **An About window** (menu bar right-click › About MacRazer). Version and build, the
+ developer, and the three things this app actually owes the person reading it: that it is
+ **not affiliated with Razer Inc.** and uses their marks only to describe compatibility; that
+ the device protocol was **ported from OpenRazer** — whose reverse-engineering this is built
+ on, and which is why the project is GPL — crediting PR #2583 by dyharlan and z3ntu for Cobra
+ HyperSpeed; and the licence and no-warranty terms, with a link to the source. Those facts
+ lived only in `NOTICE.md`, where a user never sees them. Plus a **Report an Issue** link and
+ a **tip** link. No email address: reports go to GitHub Issues, where they can be tracked and
+ where there is nothing for scrapers to harvest out of a public binary.
 - **A real Settings window** (menu bar right-click › Settings…, or the gear in the popover
  footer). The popover is for the *mouse* — DPI, polling, lighting, battery. App-level
  settings are set once and rarely revisited, and they need room to explain themselves; a
@@ -83,6 +92,10 @@ expect rough edges until 1.0.
  sub-second pure-layer run, now says what the job actually does.
 
 ### Fixed
+- Preview renders (`render-ui`, `render-settings`, `render-about`, …) now force dark, as every
+ surface they stand in for does. `.secondary` and `.tertiary` were resolving for light mode
+ and drawing near-black on the dark backdrop, so every preview looked like it had a contrast
+ bug it didn't have.
 - **Clicking the gear in the popover footer could install an update and restart the app**
  instead of opening Settings. The check is deferred a runloop turn and then asks whether the
  settings window actually came up — two earlier attempts used a flag set around the close,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ expect rough edges until 1.0.
  sub-second pure-layer run, now says what the job actually does.
 
 ### Fixed
+- An automatic update install can no longer relaunch the app out from under a window you have
+ open. The guard named the popover and the Settings window; the About, Configure Buttons and
+ Setup windows were invisible to it, so opening one from the menu bar — which closes the
+ popover, and so arms the check — could have the app replace itself and restart while you were
+ reading it. Every window controller now answers the same `AppWindowPresenter.isVisible`, and
+ the guard asks all of them: enumerating windows at the call site is what left each new one
+ exposed.
 - Preview renders (`render-ui`, `render-settings`, `render-about`, …) now force dark, as every
  surface they stand in for does. `.secondary` and `.tertiary` were resolving for light mode
  and drawing near-black on the dark backdrop, so every preview looked like it had a contrast

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -10,24 +10,9 @@ import SwiftUI
 /// mouse protocol was ported from OpenRazer — which is why the project is GPL at all, and why
 /// their credit belongs somewhere a user can actually see rather than only in `NOTICE.md`.
 struct AboutView: View {
-    var onDone: (() -> Void)?
-
-    private enum Links {
-        static let source = URL(string: "https://github.com/SorcRR/MacRazer")!
-        static let issues = URL(string: "https://github.com/SorcRR/MacRazer/issues")!
-        static let tip = URL(string: "https://ko-fi.com/sorcrr")!
-        static let developer = URL(string: "https://github.com/SorcRR")!
-        static let openRazer = URL(string: "https://github.com/openrazer/openrazer")!
-        static let cobraPR = URL(string: "https://github.com/openrazer/openrazer/pull/2583")!
-    }
-
-    /// Real bundle values; the fallbacks only show under `swift run`, which has no bundle.
-    private var version: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
-    }
-    private var build: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
-    }
+    /// Not optional: a defaulted no-op would let a caller ship a Done button that depresses
+    /// and does nothing, with no compiler error.
+    var onDone: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -55,11 +40,11 @@ struct AboutView: View {
             .frame(width: 56, height: 56)
             VStack(alignment: .leading, spacing: 3) {
                 Text("MacRazer").font(.system(size: 22, weight: .semibold))
-                Text("Version \(version) (build \(build))")
+                Text("Version \(AppInfo.displayVersion) (build \(AppInfo.displayBuild))")
                     .font(.system(size: 12)).foregroundStyle(.secondary).monospacedDigit()
                 HStack(spacing: 4) {
                     Text("by").font(.system(size: 12)).foregroundStyle(.secondary)
-                    Link("SorcRR", destination: Links.developer)
+                    Link("SorcRR", destination: ProjectLinks.developer)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(Color.razerGreen)
                 }
@@ -72,24 +57,24 @@ struct AboutView: View {
 
     private var unofficialSection: some View {
         titledSection("Unofficial") {
-            body("An independent community project. It is not affiliated with, authorized by, "
-                 + "or endorsed by Razer Inc.")
-            body("“Razer”, “Cobra”, “HyperSpeed”, “Synapse” and “Chroma” are trademarks of "
-                 + "Razer Inc., used here only to describe compatibility. The app's mouse mark "
-                 + "is its own; it does not display Razer's logo.")
+            sectionNote("An independent community project. It is not affiliated with, authorized by, "
+                        + "or endorsed by Razer Inc.")
+            sectionNote("“Razer”, “Cobra”, “HyperSpeed”, “Synapse” and “Chroma” are trademarks of "
+                        + "Razer Inc., used here only to describe compatibility. The app's mouse mark "
+                        + "is its own; it does not display Razer's logo.")
         }
     }
 
     private var openRazerSection: some View {
         titledSection("Built on OpenRazer") {
-            body("The device protocol — command bytes, the report structure, CRC, the Cobra "
-                 + "command set — was ported from OpenRazer's Linux driver. The hard "
-                 + "reverse-engineering is theirs.")
-            body("Cobra HyperSpeed support follows OpenRazer PR #2583 by dyharlan, reviewed "
-                 + "by z3ntu, which established that the device reuses the Cobra Pro protocol.")
+            sectionNote("The device protocol — command bytes, the report structure, CRC, the Cobra "
+                        + "command set — was ported from OpenRazer's Linux driver. The hard "
+                        + "reverse-engineering is theirs.")
+            sectionNote("Cobra HyperSpeed support follows OpenRazer PR #2583 by dyharlan, reviewed "
+                        + "by z3ntu, which established that the device reuses the Cobra Pro protocol.")
             HStack(spacing: 14) {
-                Link("OpenRazer", destination: Links.openRazer)
-                Link("PR #2583", destination: Links.cobraPR)
+                Link("OpenRazer", destination: ProjectLinks.openRazer)
+                Link("PR #2583", destination: ProjectLinks.cobraHyperSpeedPR)
             }
             .font(.system(size: 11.5, weight: .medium))
             .foregroundStyle(Color.razerGreen)
@@ -98,11 +83,11 @@ struct AboutView: View {
 
     private var licenseSection: some View {
         titledSection("License") {
-            body("GPL-2.0-or-later — GPL because it derives from OpenRazer, which is GPL.")
-            body("Provided as is, without warranty of any kind. It talks to your mouse over "
-                 + "HID; it only sends the same feature reports OpenRazer and Synapse use, but "
-                 + "you run it at your own risk.")
-            Link("View the source", destination: Links.source)
+            sectionNote("GPL-2.0-or-later — GPL because it derives from OpenRazer, which is GPL.")
+            sectionNote("Provided as is, without warranty of any kind. It talks to your mouse over "
+                        + "HID; it only sends the same feature reports OpenRazer and Synapse use, but "
+                        + "you run it at your own risk.")
+            Link("View the source", destination: ProjectLinks.repo)
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(Color.razerGreen)
         }
@@ -114,27 +99,20 @@ struct AboutView: View {
     /// there is no address in a public binary for scrapers to harvest.
     private var footer: some View {
         HStack(spacing: 10) {
-            Link(destination: Links.issues) {
+            Link(destination: ProjectLinks.issues) {
                 Label("Report an Issue", systemImage: "exclamationmark.bubble")
             }
             .buttonStyle(.bordered)
-            Link(destination: Links.tip) {
+            Link(destination: ProjectLinks.tip) {
                 Label("Leave a Tip", systemImage: "heart")
             }
             .buttonStyle(.bordered)
             .tint(.razerGreen)
             Spacer(minLength: 0)
-            Button("Done") { onDone?() }
+            Button("Done") { onDone() }
                 .keyboardShortcut(.defaultAction)
         }
         .controlSize(.small)
         .font(.system(size: 11.5))
-    }
-
-    private func body(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 11.5))
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import SwiftUI
+
+/// About MacRazer.
+///
+/// More than a version number, because this app has things it genuinely owes the people
+/// reading it: it uses Razer's trademarks descriptively and must say it isn't Razer's, and its
+/// mouse protocol was ported from OpenRazer — which is why the project is GPL at all, and why
+/// their credit belongs somewhere a user can actually see rather than only in `NOTICE.md`.
+struct AboutView: View {
+    var onDone: (() -> Void)?
+
+    private enum Links {
+        static let source = URL(string: "https://github.com/SorcRR/MacRazer")!
+        static let issues = URL(string: "https://github.com/SorcRR/MacRazer/issues")!
+        static let tip = URL(string: "https://ko-fi.com/sorcrr")!
+        static let developer = URL(string: "https://github.com/SorcRR")!
+        static let openRazer = URL(string: "https://github.com/openrazer/openrazer")!
+        static let cobraPR = URL(string: "https://github.com/openrazer/openrazer/pull/2583")!
+    }
+
+    /// Real bundle values; the fallbacks only show under `swift run`, which has no bundle.
+    private var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+    private var build: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            unofficialSection
+            openRazerSection
+            licenseSection
+            footer
+        }
+        .padding(22)
+        .frame(width: 460)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 13).fill(Color.razerGreenBright.opacity(0.20))
+                Image(nsImage: MenuBarIcon.mouse(pointSize: 32, razerCutout: true))
+                    .renderingMode(.template).resizable().scaledToFit()
+                    .frame(width: 32, height: 32)
+                    .foregroundStyle(Color.razerGreenBright)
+            }
+            .frame(width: 56, height: 56)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("MacRazer").font(.system(size: 22, weight: .semibold))
+                Text("Version \(version) (build \(build))")
+                    .font(.system(size: 12)).foregroundStyle(.secondary).monospacedDigit()
+                HStack(spacing: 4) {
+                    Text("by").font(.system(size: 12)).foregroundStyle(.secondary)
+                    Link("SorcRR", destination: Links.developer)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(Color.razerGreen)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: Sections
+
+    private var unofficialSection: some View {
+        titledSection("Unofficial") {
+            body("An independent community project. It is not affiliated with, authorized by, "
+                 + "or endorsed by Razer Inc.")
+            body("“Razer”, “Cobra”, “HyperSpeed”, “Synapse” and “Chroma” are trademarks of "
+                 + "Razer Inc., used here only to describe compatibility. The app's mouse mark "
+                 + "is its own; it does not display Razer's logo.")
+        }
+    }
+
+    private var openRazerSection: some View {
+        titledSection("Built on OpenRazer") {
+            body("The device protocol — command bytes, the report structure, CRC, the Cobra "
+                 + "command set — was ported from OpenRazer's Linux driver. The hard "
+                 + "reverse-engineering is theirs.")
+            body("Cobra HyperSpeed support follows OpenRazer PR #2583 by dyharlan, reviewed "
+                 + "by z3ntu, which established that the device reuses the Cobra Pro protocol.")
+            HStack(spacing: 14) {
+                Link("OpenRazer", destination: Links.openRazer)
+                Link("PR #2583", destination: Links.cobraPR)
+            }
+            .font(.system(size: 11.5, weight: .medium))
+            .foregroundStyle(Color.razerGreen)
+        }
+    }
+
+    private var licenseSection: some View {
+        titledSection("License") {
+            body("GPL-2.0-or-later — GPL because it derives from OpenRazer, which is GPL.")
+            body("Provided as is, without warranty of any kind. It talks to your mouse over "
+                 + "HID; it only sends the same feature reports OpenRazer and Synapse use, but "
+                 + "you run it at your own risk.")
+            Link("View the source", destination: Links.source)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(Color.razerGreen)
+        }
+    }
+
+    // MARK: Footer
+
+    /// Issues rather than an email address: reports land somewhere they can be tracked, and
+    /// there is no address in a public binary for scrapers to harvest.
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Link(destination: Links.issues) {
+                Label("Report an Issue", systemImage: "exclamationmark.bubble")
+            }
+            .buttonStyle(.bordered)
+            Link(destination: Links.tip) {
+                Label("Leave a Tip", systemImage: "heart")
+            }
+            .buttonStyle(.bordered)
+            .tint(.razerGreen)
+            Spacer(minLength: 0)
+            Button("Done") { onDone?() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .controlSize(.small)
+        .font(.system(size: 11.5))
+    }
+
+    private func body(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11.5))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/Sources/MacRazer/AboutWindowController.swift
+++ b/Sources/MacRazer/AboutWindowController.swift
@@ -6,8 +6,10 @@ import SwiftUI
 
 /// Hosts About MacRazer in a normal window, reached from the menu bar's right-click menu.
 @MainActor
-final class AboutWindowController {
+final class AboutWindowController: AppWindowPresenter {
     private var window: NSWindow?
+
+    var isVisible: Bool { window?.isVisible ?? false }
 
     func show() {
         if window == nil {

--- a/Sources/MacRazer/AboutWindowController.swift
+++ b/Sources/MacRazer/AboutWindowController.swift
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import AppKit
+import SwiftUI
+
+/// Hosts About MacRazer in a normal window, reached from the menu bar's right-click menu.
+@MainActor
+final class AboutWindowController {
+    private var window: NSWindow?
+
+    func show() {
+        if window == nil {
+            let root = AboutView(onDone: { [weak self] in self?.window?.close() })
+            let hosting = NSHostingController(rootView: root)
+            hosting.sizingOptions = [.preferredContentSize]
+            let w = NSWindow(contentViewController: hosting)
+            w.title = "About MacRazer"
+            w.styleMask = [.titled, .closable]
+            w.isReleasedWhenClosed = false
+            // Match the popover and the other windows: the green accent needs a dark ground.
+            w.appearance = NSAppearance(named: .darkAqua)
+            w.center()
+            window = w
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+    }
+}

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -21,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     private lazy var permissionsWindow = PermissionsWindowController(model: permissions, controller: controller)
     private let updateChecker = UpdateChecker()
     private let launchAtLogin = LaunchAtLogin()
+    private lazy var aboutWindow = AboutWindowController()
     private lazy var settingsWindow = SettingsWindowController(
         controller: controller, launchAtLogin: launchAtLogin, updateChecker: updateChecker,
         onAutoInstallChanged: { [weak self] in self?.autoInstallSettingChanged() })
@@ -269,6 +270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         setup.target = self
         menu.addItem(setup)
 
+        // About before Settings, as macOS orders them in an app menu.
+        let about = NSMenuItem(title: "About MacRazer", action: #selector(openAbout), keyEquivalent: "")
+        about.target = self
+        menu.addItem(about)
+
         let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
         settings.target = self
         menu.addItem(settings)
@@ -311,6 +317,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     }
     @objc private func openRemap() { remapWindow.show() }
     @objc private func openSettings() { settingsWindow.show() }
+    @objc private func openAbout() { aboutWindow.show() }
 
     /// Turning the setting on with an update already found is the one moment a user is
     /// watching for it to act, and neither of the other triggers fires then: `latestVersion`

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -321,6 +321,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
     @objc private func openSettings() { settingsWindow.show() }
     @objc private func openAbout() { aboutWindow.show() }
 
+    /// Whether the user is currently looking at one of the app's windows.
+    ///
+    /// Touching the lazy controllers here builds the controllers but not their windows — each
+    /// initializer only stores a few references, and the `NSWindow` is still created on the
+    /// first `show()`. So the laziness that matters is intact.
+    private var isShowingAWindow: Bool {
+        let windows: [AppWindowPresenter] = [remapWindow, permissionsWindow, aboutWindow, settingsWindow]
+        return windows.contains { $0.isVisible }
+    }
+
     /// Turning the setting on with an update already found is the one moment a user is
     /// watching for it to act, and neither of the other triggers fires then: `latestVersion`
     /// hasn't changed (so the deduplicated sink stays quiet) and the popover was never open.
@@ -358,10 +368,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
             enabled: updateChecker.autoInstallEnabled,
             canInstallInPlace: updateChecker.canInstallInPlace,
             busy: updateChecker.isBusy,
-            // Neither surface may be yanked away mid-use: the popover for the reason above,
-            // and the settings window because closing the popover to open it must not be read
-            // as permission to restart the app.
-            popoverVisible: popover.isShown || settingsWindow.isVisible)
+            // No surface may be yanked away mid-use: the popover for the reason above, and
+            // any window the app has open, because an install ends in a relaunch. Asked of
+            // every window rather than a named one — enumerating them here is what left the
+            // About window exposed the moment it was added.
+            popoverVisible: popover.isShown || isShowingAWindow)
         // The policy returns the version it approved rather than a Bool: it records the
         // attempt as part of deciding, so a caller that had to re-unwrap afterwards could
         // silently drop a version already marked as spent.

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -248,6 +248,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
 
         let menu = NSMenu()
 
+        // First, where macOS puts About in an app menu — above the device header, which is a
+        // title for the items below it rather than an item itself.
+        let about = NSMenuItem(title: "About MacRazer", action: #selector(openAbout), keyEquivalent: "")
+        about.target = self
+        menu.addItem(about)
+        menu.addItem(.separator())
+
         let status = NSMenuItem(title: appMenuStatusTitle(), action: nil, keyEquivalent: "")
         status.isEnabled = false
         menu.addItem(status)
@@ -269,11 +276,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         let setup = NSMenuItem(title: "Setup & Permissions…", action: #selector(openPermissions), keyEquivalent: "")
         setup.target = self
         menu.addItem(setup)
-
-        // About before Settings, as macOS orders them in an app menu.
-        let about = NSMenuItem(title: "About MacRazer", action: #selector(openAbout), keyEquivalent: "")
-        about.target = self
-        menu.addItem(about)
 
         let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
         settings.target = self

--- a/Sources/MacRazer/AppInfo.swift
+++ b/Sources/MacRazer/AppInfo.swift
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// What the app knows about itself. One place, because four files had grown their own read of
+/// `CFBundleShortVersionString` and they didn't agree on the fallback — which mattered, since
+/// one of those disagreements is deliberate (see below) and the rest were accidents.
+enum AppInfo {
+    /// The bundle's marketing version, or nil under `swift run`, which has no bundle.
+    static var version: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    static var build: String? {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+
+    /// For showing a human. "dev" reads as what it is.
+    static var displayVersion: String { version ?? "dev" }
+
+    static var displayBuild: String { build ?? "—" }
+
+    /// For `VersionCompare`. Deliberately **not** `displayVersion`: "0" sorts older than any
+    /// real release, so a dev build always sees an update as available, whereas "dev" parses
+    /// to 0 by accident rather than by intent and reads as a bug when you meet it.
+    static var comparableVersion: String { version ?? "0" }
+}
+
+/// Every URL that identifies this project. Also one place: the repository host appeared in
+/// four files, so a rename would have left the updater polling one place while the About
+/// window linked to another — and nothing would have failed loudly, the update card would
+/// just have quietly stopped finding releases.
+enum ProjectLinks {
+    static let repo = URL(string: "https://github.com/SorcRR/MacRazer")!
+    static let site = URL(string: "https://sorcrr.github.io/MacRazer/")!
+    static let tip = URL(string: "https://ko-fi.com/sorcrr")!
+    static let developer = URL(string: "https://github.com/SorcRR")!
+
+    static let issues = repo.appendingPathComponent("issues")
+    /// GitHub's fixed "latest" shortcut; `Scripts/make-dmg.sh` keeps the asset name constant
+    /// precisely so this URL never has to change.
+    static let latestDMG = repo.appendingPathComponent("releases/latest/download/MacRazer.dmg")
+    static let latestReleaseAPI =
+        URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
+
+    // Upstream, credited in the About window and NOTICE.md.
+    static let openRazer = URL(string: "https://github.com/openrazer/openrazer")!
+    static let cobraHyperSpeedPR = URL(string: "https://github.com/openrazer/openrazer/pull/2583")!
+}

--- a/Sources/MacRazer/AppWindows.swift
+++ b/Sources/MacRazer/AppWindows.swift
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// A window the app can put on screen. Exists so callers can ask "is the user in one of our
+/// windows?" without naming them.
+///
+/// That question has one caller and a sharp reason: an automatic update install ends in a
+/// relaunch, so it must not start while the user is looking at something. It was originally
+/// written as `popover.isShown || settingsWindow.isVisible` — which then had to be corrected
+/// three times, and still missed Remap, Permissions, and About the moment About was added.
+/// Enumerating windows at the call site is what kept going wrong; this makes adding a window
+/// a matter of conforming it, not of remembering a predicate somewhere else.
+@MainActor
+protocol AppWindowPresenter: AnyObject {
+    /// Whether this controller's window is currently on screen. False before `show()` has ever
+    /// been called, since the window is built lazily.
+    var isVisible: Bool { get }
+}

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -13,9 +13,12 @@ func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
 }
 
 /// A card with a small uppercase heading — the window-sized counterpart to `card`, shared by
-/// the Settings and About windows so their sections can't drift apart. Slightly flatter and
-/// tighter-cornered than `card`: those sit on the popover's dark material, these on a plain
-/// window background where the popover's contrast would read as heavy.
+/// the Settings and About windows so their sections can't drift apart.
+///
+/// Flatter and tighter-cornered than `card` (0.07 vs 0.10 fill, radius 12 vs 13) but roomier
+/// inside it (14 vs 12): `card` sits on the popover's dark material at popover width, this
+/// sits on a plain window background at more than twice that, where the popover's contrast
+/// reads as heavy and its padding as cramped.
 func titledSection<Content: View>(_ title: String, @ViewBuilder _ content: () -> Content) -> some View {
     VStack(alignment: .leading, spacing: 12) {
         Text(title.uppercased())
@@ -27,6 +30,17 @@ func titledSection<Content: View>(_ title: String, @ViewBuilder _ content: () ->
     .padding(14)
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+}
+
+/// Wrapped explanatory text under a control or heading — the small secondary paragraph both
+/// the Settings and About windows are mostly made of. Shared for the same reason as
+/// `titledSection`: the two windows had grown separate copies, one of them named `body`, which
+/// shadows the `View` requirement it sat next to.
+func sectionNote(_ text: String, color: Color = .secondary) -> some View {
+    Text(text)
+        .font(.system(size: 11.5))
+        .foregroundStyle(color)
+        .fixedSize(horizontal: false, vertical: true)
 }
 
 /// Small secondary-styled section heading used inside cards.

--- a/Sources/MacRazer/CardComponents.swift
+++ b/Sources/MacRazer/CardComponents.swift
@@ -12,6 +12,23 @@ func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         .background(Color.primary.opacity(0.10), in: RoundedRectangle(cornerRadius: 13))
 }
 
+/// A card with a small uppercase heading — the window-sized counterpart to `card`, shared by
+/// the Settings and About windows so their sections can't drift apart. Slightly flatter and
+/// tighter-cornered than `card`: those sit on the popover's dark material, these on a plain
+/// window background where the popover's contrast would read as heavy.
+func titledSection<Content: View>(_ title: String, @ViewBuilder _ content: () -> Content) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+        Text(title.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .kerning(0.6)
+        content()
+    }
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+}
+
 /// Small secondary-styled section heading used inside cards.
 func sectionLabel(_ text: String, _ symbol: String) -> some View {
     Label(text, systemImage: symbol)

--- a/Sources/MacRazer/PermissionsWindowController.swift
+++ b/Sources/MacRazer/PermissionsWindowController.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Hosts the first-run setup / permissions screen in a normal window. Shown automatically on the
 /// very first launch and reachable any time from the menu bar's "Setup & Permissions…".
 @MainActor
-final class PermissionsWindowController {
+final class PermissionsWindowController: AppWindowPresenter {
     private var window: NSWindow?
     private let model: PermissionsModel
     private let controller: MouseController
@@ -16,6 +16,8 @@ final class PermissionsWindowController {
         self.model = model
         self.controller = controller
     }
+
+    var isVisible: Bool { window?.isVisible ?? false }
 
     func show() {
         if window == nil {

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -845,19 +845,11 @@ struct PopoverView: View {
 
     // MARK: Footer
 
-    /// Real bundle version (e.g. "0.1.1"); falls back for non-bundled dev runs (`swift run`).
-    private var appVersion: String {
-        (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "dev"
-    }
-
-    /// The project page. A menu bar app has nowhere to put an "About", and the version line is
-    /// already what people look at to answer "what am I running" — so it doubles as the way
-    /// there, rather than adding another row to a popover that's long enough.
-    private static let websiteURL = URL(string: "https://sorcrr.github.io/MacRazer/")!
+    private var appVersion: String { AppInfo.displayVersion }
 
     private var footer: some View {
         HStack(spacing: 4) {
-            Link(destination: Self.websiteURL) {
+            Link(destination: ProjectLinks.site) {
                 Text(verbatim: "v\(appVersion)")
                     .font(.system(size: 11))
                     // Nothing at rest marks it as a link — the footer should stay quiet — so

--- a/Sources/MacRazer/RemapWindowController.swift
+++ b/Sources/MacRazer/RemapWindowController.swift
@@ -7,11 +7,13 @@ import SwiftUI
 /// Hosts the button-remapping UI in a normal window (the popover is for quick controls only).
 /// An accessory app can show a window; we just activate first so it comes to the front.
 @MainActor
-final class RemapWindowController {
+final class RemapWindowController: AppWindowPresenter {
     private var window: NSWindow?
     private let remapper: ButtonRemapper
 
     init(remapper: ButtonRemapper) { self.remapper = remapper }
+
+    var isVisible: Bool { window?.isVisible ?? false }
 
     func show() {
         if window == nil {

--- a/Sources/MacRazer/SettingsView.swift
+++ b/Sources/MacRazer/SettingsView.swift
@@ -23,13 +23,13 @@ struct SettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             header
-            section("General") {
+            titledSection("General") {
                 launchAtLoginRow
                 // Hidden rather than disabled for a mouse with no battery: there is no
                 // percentage to show, so the switch would be a promise about nothing.
                 if controller.deviceHasBattery { batteryPercentRow }
             }
-            section("Updates") {
+            titledSection("Updates") {
                 autoInstallRow
                 versionRow
             }
@@ -206,19 +206,6 @@ struct SettingsView: View {
             .font(.system(size: 11))
             .foregroundStyle(color)
             .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title.uppercased())
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .kerning(0.6)
-            content()
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
     }
 
     private var footer: some View {

--- a/Sources/MacRazer/SettingsView.swift
+++ b/Sources/MacRazer/SettingsView.swift
@@ -14,7 +14,9 @@ struct SettingsView: View {
     @ObservedObject var controller: MouseController
     @ObservedObject var launchAtLogin: LaunchAtLogin
     @ObservedObject var updateChecker: UpdateChecker
-    var onDone: (() -> Void)?
+    /// Not optional, for the same reason as `AboutView.onDone`: a defaulted no-op ships a
+    /// Done button that does nothing and compiles fine.
+    var onDone: () -> Void
     /// Called when "install automatically" is switched, so the owner can act on an update that
     /// is *already* known — the one moment the user is watching for the setting to do
     /// something, and the moment none of the other triggers fire.
@@ -74,10 +76,10 @@ struct SettingsView: View {
             // Shown rather than hidden when unavailable: running straight from the disk image
             // is a real thing people do, and "why is this switch dead" deserves an answer.
             if !launchAtLogin.isSupported {
-                note("Move MacRazer to your Applications folder to use this — a login item "
+                sectionNote("Move MacRazer to your Applications folder to use this — a login item "
                      + "pointing into a disk image stops working the moment it's ejected.")
             } else if let error = launchAtLogin.lastError {
-                note(error, color: .batteryLow)
+                sectionNote(error, color: .batteryLow)
             } else if launchAtLogin.needsApproval {
                 Button("Approve MacRazer in Login Items…") { launchAtLogin.openLoginItemsSettings() }
                     .buttonStyle(.plain).font(.system(size: 11))
@@ -107,10 +109,10 @@ struct SettingsView: View {
             enabled: updateChecker.canInstallInPlace
         ) {
             if !updateChecker.canInstallInPlace {
-                note("Unavailable here — MacRazer can't replace itself from this location. "
+                sectionNote("Unavailable here — MacRazer can't replace itself from this location. "
                      + "Move it to your Applications folder.")
             } else if !updateChecker.autoInstallEnabled {
-                note("Off: you'll get a dot on the menu bar icon and a card in the popover instead.")
+                sectionNote("Off: you'll get a dot on the menu bar icon and a card in the popover instead.")
             }
         }
     }
@@ -195,23 +197,16 @@ struct SettingsView: View {
             .tint(.razerGreen)
             .controlSize(.small)
             .disabled(!enabled)
-            note(detail)
+            sectionNote(detail)
             extra()
         }
         .opacity(enabled ? 1 : 0.55)
     }
 
-    private func note(_ text: String, color: Color = .secondary) -> some View {
-        Text(text)
-            .font(.system(size: 11))
-            .foregroundStyle(color)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
     private var footer: some View {
         HStack {
             Spacer()
-            Button("Done") { onDone?() }
+            Button("Done") { onDone() }
                 .keyboardShortcut(.defaultAction)
         }
     }

--- a/Sources/MacRazer/SettingsWindowController.swift
+++ b/Sources/MacRazer/SettingsWindowController.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Hosts the app's settings in a normal window. Reachable from the menu bar's right-click
 /// menu (⌘,) and from the gear in the popover footer.
 @MainActor
-final class SettingsWindowController {
+final class SettingsWindowController: AppWindowPresenter {
     private var window: NSWindow?
     private let controller: MouseController
     private let launchAtLogin: LaunchAtLogin

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -60,8 +60,8 @@ final class UpdateChecker: ObservableObject {
         didSet { UserDefaults.standard.set(autoInstallEnabled, forKey: Self.autoInstallKey) }
     }
 
-    private let releaseAPIURL = URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
-    private let dmgURL = URL(string: "https://github.com/SorcRR/MacRazer/releases/latest/download/MacRazer.dmg")!
+    private let releaseAPIURL = ProjectLinks.latestReleaseAPI
+    private let dmgURL = ProjectLinks.latestDMG
     private let checkInterval: TimeInterval = 24 * 60 * 60
 
     private static let dismissedKey = "dismissedUpdateVersion"
@@ -73,11 +73,7 @@ final class UpdateChecker: ObservableObject {
         let tag_name: String
     }
 
-    /// The bundle's version, or "0" under `swift run` where there is no bundle — which
-    /// compares older than any real release, so a dev build always sees an update available.
-    var currentVersion: String {
-        (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0"
-    }
+    var currentVersion: String { AppInfo.comparableVersion }
 
     var isBusy: Bool { phase != .idle }
 

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -59,7 +59,13 @@ func openDevice() -> HIDDevice? {
 /// Shared by the render-* commands: draw a SwiftUI view at 2x on the app's dark backdrop
 /// and write it to a PNG.
 @MainActor func writeViewPNG<V: View>(_ view: V, to path: String) {
-    let renderer = ImageRenderer(content: view.padding(1).background(Color(white: 0.13)))
+    // Force dark, because every surface these previews stand in for does: the popover sets
+    // `.darkAqua`, and so do the Settings, Permissions and About windows. Without it
+    // `.secondary`/`.tertiary` resolve for light mode and render as near-black text on the
+    // dark backdrop below — which made every preview look like it had a contrast bug it
+    // doesn't have.
+    let renderer = ImageRenderer(
+        content: view.environment(\.colorScheme, .dark).padding(1).background(Color(white: 0.13)))
     renderer.scale = 2
     if let img = renderer.nsImage,
        let tiff = img.tiffRepresentation,
@@ -153,6 +159,10 @@ case "render-settings":
     if args.contains("update") { su.loadPreviewState() }
     writeViewPNG(SettingsView(controller: sc, launchAtLogin: sl, updateChecker: su),
                  to: settingsPath)
+
+case "render-about":
+    _ = NSApplication.shared
+    writeViewPNG(AboutView(), to: args.dropFirst().first ?? "about-preview.png")
 
 case "render-remap":
     _ = NSApplication.shared

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -157,12 +157,13 @@ case "render-settings":
     // `update` shows the Updates section in its available state, which is the only way to see
     // the Install Now button without waiting for a real release.
     if args.contains("update") { su.loadPreviewState() }
-    writeViewPNG(SettingsView(controller: sc, launchAtLogin: sl, updateChecker: su),
+    writeViewPNG(SettingsView(controller: sc, launchAtLogin: sl, updateChecker: su, onDone: {}),
                  to: settingsPath)
 
 case "render-about":
     _ = NSApplication.shared
-    writeViewPNG(AboutView(), to: args.dropFirst().first ?? "about-preview.png")
+    let aboutPath = args.dropFirst().first ?? "about-preview.png"
+    writeViewPNG(AboutView(onDone: {}), to: aboutPath) // no window to close in a render
 
 case "render-remap":
     _ = NSApplication.shared


### PR DESCRIPTION
Menu bar right-click › **About MacRazer**.

Version and build, the developer, and the three things this app actually owes the person reading it — all of which lived only in `NOTICE.md`, where a user never looks:

- **Not affiliated with Razer Inc.** The app uses Razer's marks descriptively; saying so in-app is protective, not decorative.
- **Built on OpenRazer.** The device protocol was ported from their Linux driver — that reverse-engineering is theirs, and it is why this project is GPL at all. Credits PR #2583 by dyharlan, reviewed by z3ntu, for Cobra HyperSpeed.
- **Licence and no-warranty**, with a link to the source.

Plus **Report an Issue** and a **tip** link.

## No email address

Deliberate, and worth flagging since it differs from the usual "developer info" shape: contact is GitHub Issues. Reports land where they can be tracked, and a public binary carries nothing for scrapers to harvest. Easy to add an address later if you'd rather.

## Also

- `SettingsView` had grown a private `section` helper duplicating the shared `card`. It moves to `CardComponents` as `titledSection` so the two windows can't drift — rather than a third copy appearing in About.
- Preview renders now force dark, as every surface they stand in for does. `.secondary`/`.tertiary` were resolving for light mode and drawing near-black on the dark backdrop, so **every** preview this session looked like it had a contrast bug it didn't have. `render-settings` and `render-ui` are more honest now too.
- New `render-about` preview command, matching the existing ones.

`swift build` clean, 102 tests pass, About and Settings both verified via renders.