### PR TITLE
Add a release script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,20 @@ jobs:
       # that ever changes.
       - name: Check shell scripts
         run: |
-          bash -n Scripts/*.sh
+          bash -n Scripts/*.sh Tests/Scripts/*.sh
           if command -v shellcheck >/dev/null; then
             # -S error only: these scripts predate any linting, and the point here is to
             # catch what would actually break a release, not to relitigate their style.
-            shellcheck -S error Scripts/*.sh
+            shellcheck -S error Scripts/*.sh Tests/Scripts/*.sh
           else
             echo "shellcheck unavailable on this runner — syntax check only"
           fi
+      # The release script decides things — which version is newer, where the changelog gets
+      # cut — and `bash -n` only proves it parses. It shipped with two individually-valid
+      # patterns that disagreed with each other, which is the kind of defect only a fixture
+      # test catches.
+      - name: Test shell scripts
+        run: ./Tests/Scripts/release-test.sh
       - name: Build
         run: swift build
       - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ expect rough edges until 1.0.
  refuses if the version isn't newer — using the same comparison the app makes — or if the
  tree is dirty, master is out of sync, or `[Unreleased]` is empty, and it verifies the built
  app reports the version being tagged before it says it's done. It stops short of committing,
- tagging and publishing, printing those commands instead.
+ tagging and publishing, printing those commands instead, and if it stops part-way it says how
+ to undo the edits it had already made. `Tests/Scripts/release-test.sh` covers the version
+ comparison and both changelog operations, and CI runs it — `bash -n` and shellcheck prove a
+ script parses, not that two of its patterns agree with each other.
 
 ### Added
 - **An About window**, first in the menu bar's right-click menu, where macOS puts About. Version and build, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Added
+- **`Scripts/release.sh`** — cutting a release now bumps every place the version is recorded
+ and closes off the changelog in one step, instead of four hand edits that have to agree.
+ They have to agree because the in-app updater compares the GitHub tag against the running
+ bundle's own version: a release tagged `v0.3.0` whose bundle still said `0.2.1` would leave
+ every user with an update badge they could never clear — the app installs it, still reports
+ the old version, and finds the same release "newer" on the next check. (`UpdateInstaller`'s
+ newer-than check stops that looping, so it fails safe, but the badge would stay.) The script
+ refuses if the version isn't newer — using the same comparison the app makes — or if the
+ tree is dirty, master is out of sync, or `[Unreleased]` is empty, and it verifies the built
+ app reports the version being tagged before it says it's done. It stops short of committing,
+ tagging and publishing, printing those commands instead.
+
+### Added
 - **An About window**, first in the menu bar's right-click menu, where macOS puts About. Version and build, the
  developer, and the three things this app actually owes the person reading it: that it is
  **not affiliated with Razer Inc.** and uses their marks only to describe compatibility; that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ swift run MacRazer # menu bar app (uses your Terminal's permission grants)
 swift run MacRazer battery # CLI diagnostics: battery / dpi / poll / rgb / brightness / info
 swift test # unit tests (protocol codec, battery models, persistence — no hardware needed)
 ./Scripts/build-app.sh # build a standalone .app
-./Scripts/make-dmg.sh # package the .app into dist/MacRazer.dmg for a release
+./Scripts/make-dmg.sh # package the .app into dist/MacRazer.dmg
+./Scripts/release.sh 0.3.0 # cut a release: bump every version, close the changelog, build
 ```
 macOS 14+, Swift 6.1 / Xcode 16+. CI runs `swift build && swift test` on pushes to master
 and on every PR; please run the tests locally before opening a PR, and add a test when you
@@ -21,6 +22,21 @@ fix logic in the pure layers (anything without live HID in it).
 `make-dmg.sh` produces an unsigned/self-signed DMG (no paid Apple Developer ID), so it
 triggers a Gatekeeper warning on first launch. That's expected; the README's Install section
 has the bypass steps to link in release notes.
+
+## Cutting a release
+
+Use `./Scripts/release.sh <version>` rather than editing by hand. The version is recorded in
+three places and the changelog in a fourth, and they have to agree: the in-app updater
+compares the GitHub tag against the running bundle's own version, so a release tagged
+`v0.3.0` whose bundle still says `0.2.1` leaves every user with an update badge they can
+never clear. The script bumps all of them, promotes `## [Unreleased]` to a dated version
+heading, builds both DMGs, and refuses outright if the version isn't newer, the tree is
+dirty, you're not on an up-to-date master, or `[Unreleased]` is empty.
+
+It stops before `git commit`, `git tag` and `gh release create`, printing them — review the
+diff first. Attach **both** DMGs to the release: the updater fetches the fixed
+`MacRazer.dmg` name, and the versioned copy makes the Releases page self-describing.
+`--dry-run` shows what it would do.
 
 ## The most valuable contribution: device profiles
 Detection + name work for **any** Razer mouse already (via the USB product string). What's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ swift run MacRazer battery # CLI diagnostics: battery / dpi / poll / rgb / brigh
 swift test # unit tests (protocol codec, battery models, persistence — no hardware needed)
 ./Scripts/build-app.sh # build a standalone .app
 ./Scripts/make-dmg.sh # package the .app into dist/MacRazer.dmg
-./Scripts/release.sh 0.3.0 # cut a release: bump every version, close the changelog, build
+./Scripts/release.sh 0.3.0 --dry-run # preview a release (see 'Cutting a release' below)
 ```
 macOS 14+, Swift 6.1 / Xcode 16+. CI runs `swift build && swift test` on pushes to master
 and on every PR; please run the tests locally before opening a PR, and add a test when you
@@ -34,7 +34,8 @@ heading, builds both DMGs, and refuses outright if the version isn't newer, the 
 dirty, you're not on an up-to-date master, or `[Unreleased]` is empty.
 
 It stops before `git commit`, `git tag` and `gh release create`, printing them — review the
-diff first. Attach **both** DMGs to the release: the updater fetches the fixed
+diff first. `Tests/Scripts/release-test.sh` covers the version comparison and both changelog
+operations; CI runs it. Attach **both** DMGs to the release: the updater fetches the fixed
 `MacRazer.dmg` name, and the versioned copy makes the Releases page self-describing.
 `--dry-run` shows what it would do.
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -43,6 +43,24 @@ done
 fail() { echo "✗ $*" >&2; exit 1; }
 step() { echo "▸ $*"; }
 
+# Every edit happens before the build, so a build failure would otherwise exit with three
+# files rewritten and nothing said about it — and the obvious retry then refuses with "working
+# tree is dirty", which is true but describes the script's own mess. Say what to run instead.
+TEMP_FILES=""
+EDITS_APPLIED=0
+on_exit() {
+    local status=$?
+    # shellcheck disable=SC2086
+    [ -n "${TEMP_FILES}" ] && rm -f ${TEMP_FILES}
+    if [ "${status}" -ne 0 ] && [ "${EDITS_APPLIED}" -eq 1 ]; then
+        echo >&2
+        echo "✗ Stopped part-way with the release edits already applied. To undo them:" >&2
+        echo "    git checkout -- ${PLIST} ${CHANGELOG} ${SITE}" >&2
+    fi
+    return "${status}"
+}
+trap on_exit EXIT
+
 # --- Preconditions ------------------------------------------------------------------------
 # Every one of these has a failure mode that is worse to discover after the tag is pushed.
 
@@ -54,17 +72,30 @@ echo "${VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+)*$' \
 CURRENT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${PLIST}")"
 CURRENT_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "${PLIST}")"
 
+# 5: `CURRENT` feeds an unquoted expansion in version_gt below, and comes from the plist
+# rather than from an argument we validated. Hold it to the same shape.
+echo "${CURRENT}" | grep -Eq '^[0-9]+(\.[0-9]+)*$' \
+    || fail "${PLIST} has CFBundleShortVersionString '${CURRENT}', which isn't dotted integers"
+# 3: the build number is incremented, so it has to be one. CFBundleVersion legitimately holds
+# dotted strings in other projects, and the arithmetic would fail with a bare bash error.
+echo "${CURRENT_BUILD}" | grep -Eq '^[0-9]+$' \
+    || fail "${PLIST} has CFBundleVersion '${CURRENT_BUILD}', which isn't an integer to increment"
+
 # Same comparison the app makes, so the script can't approve a release the updater would
 # refuse to install.
 version_gt() {
+    # Word splitting on `.` also globs; both arguments are validated above, and this makes the
+    # function safe on its own terms rather than only in this caller's context.
+    set -f
     local IFS=.
     local -a a=($1) b=($2)
     local i x y
     for ((i = 0; i < ${#a[@]} || i < ${#b[@]}; i++)); do
         x=${a[i]:-0}; y=${b[i]:-0}
-        ((10#$x > 10#$y)) && return 0
-        ((10#$x < 10#$y)) && return 1
+        ((10#$x > 10#$y)) && { set +f; return 0; }
+        ((10#$x < 10#$y)) && { set +f; return 1; }
     done
+    set +f
     return 1
 }
 version_gt "${VERSION}" "${CURRENT}" \
@@ -81,11 +112,22 @@ git fetch -q origin master
 [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" ] \
     || fail "master is not in sync with origin/master — pull or push first"
 
-# An empty Unreleased section means there is nothing to release, and would silently produce a
+# One literal, matched exactly, used by both the check below and the rewrite later.
+#
+# These were written separately and disagreed on the anchor, so a decorated heading like
+# "## [Unreleased] (next)" passed the check and was then silently not rewritten — a release
+# whose changelog had no version heading at all, reported as a success. Sharing a *regex*
+# between them turned out to be its own trap: `awk -v` processes escapes in the value, so
+# `\[Unreleased\]` arrives as `[Unreleased]`, a character class matching one letter. An exact
+# string comparison has no escaping to get wrong and says precisely what is meant.
+UNRELEASED_HEADING='## [Unreleased]'
+
+# An empty Unreleased section means there is nothing to release, and would otherwise produce a
 # version heading with no entries under it.
-UNRELEASED_ENTRIES="$(awk '/^## \[Unreleased\]/{f=1; next} /^## \[/{f=0} f && /^- /' "${CHANGELOG}" | wc -l | tr -d ' ')"
+UNRELEASED_ENTRIES="$(awk -v h="${UNRELEASED_HEADING}" \
+    '$0 == h {f=1; next} /^## \[/{f=0} f && /^- /' "${CHANGELOG}" | wc -l | tr -d ' ')"
 [ "${UNRELEASED_ENTRIES}" -gt 0 ] \
-    || fail "CHANGELOG has no entries under [Unreleased] — nothing to release"
+    || fail "CHANGELOG has no entries under a line reading exactly '${UNRELEASED_HEADING}' — nothing to release"
 
 NEXT_BUILD=$((CURRENT_BUILD + 1))
 TODAY="$(date +%Y-%m-%d)"
@@ -102,6 +144,7 @@ fi
 
 # --- Edits --------------------------------------------------------------------------------
 
+EDITS_APPLIED=1
 step "Bumping ${PLIST}…"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" "${PLIST}"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${NEXT_BUILD}" "${PLIST}"
@@ -109,15 +152,22 @@ step "Bumping ${PLIST}…"
 step "Closing off ${CHANGELOG}…"
 # Insert the new heading directly under [Unreleased]: everything already written falls under
 # it, and [Unreleased] is left empty for the next cycle.
-awk -v ver="${VERSION}" -v today="${TODAY}" '
+CHANGELOG_TMP="$(mktemp -t macrazer-changelog)"
+TEMP_FILES="${TEMP_FILES} ${CHANGELOG_TMP}"
+awk -v ver="${VERSION}" -v today="${TODAY}" -v h="${UNRELEASED_HEADING}" '
     { print }
-    /^## \[Unreleased\]$/ && !done { print ""; print "## [" ver "] — " today; done = 1 }
-' "${CHANGELOG}" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "${CHANGELOG}"
+    $0 == h && !inserted { print ""; print "## [" ver "] — " today; inserted = 1 }
+    END { exit inserted ? 0 : 1 }
+' "${CHANGELOG}" > "${CHANGELOG_TMP}" \
+    || fail "no line reading exactly '${UNRELEASED_HEADING}' in ${CHANGELOG} — nothing was promoted"
+mv "${CHANGELOG_TMP}" "${CHANGELOG}"
 
 step "Updating ${SITE}…"
 # Only the structured-data field is hardcoded; the visible version tags fetch the latest tag
 # from the GitHub API at page load, so they follow on their own.
-sed -i '' "s/\"softwareVersion\": \"${CURRENT}\"/\"softwareVersion\": \"${VERSION}\"/" "${SITE}"
+# Matched by shape, not by the old value: interpolating `0.2.1` into a regex made each dot a
+# wildcard, and the grep below would have been just as happy if that had matched the wrong line.
+sed -i '' "s/\"softwareVersion\": \"[^\"]*\"/\"softwareVersion\": \"${VERSION}\"/" "${SITE}"
 grep -q "\"softwareVersion\": \"${VERSION}\"" "${SITE}" \
     || fail "couldn't update softwareVersion in ${SITE} — is it still there?"
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Cut a release: bump the version everywhere it is recorded, close off the changelog, build
+# the DMGs, and check the result is self-consistent.
+#
+#   ./Scripts/release.sh 0.3.0             # do it
+#   ./Scripts/release.sh 0.3.0 --dry-run   # show what it would do, touch nothing
+#
+# The version lives in three places and the changelog in a fourth, and they have to agree.
+# That mattered little when a stale version was cosmetic; since the in-app updater compares
+# the GitHub tag against the running bundle's own version, a release tagged v0.3.0 whose
+# bundle still says 0.2.1 leaves every user with an update badge they can never clear — the
+# app installs the update, still reports the old version, and finds the same release "newer"
+# on every check. `UpdateInstaller`'s notNewer guard stops it looping, so it fails safe, but
+# the badge never goes away. This script exists so that can't be forgotten.
+#
+# It deliberately stops before `git commit`, `git tag` and `gh release create`: it makes the
+# error-prone edits and leaves the outward-facing, hard-to-undo steps to you, with the exact
+# commands printed at the end. Review the diff first, as you would any other change.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PLIST="Packaging/Info.plist"
+CHANGELOG="CHANGELOG.md"
+SITE="docs/index.html"
+
+DRY_RUN=0
+VERSION=""
+for arg in "$@"; do
+    case "${arg}" in
+        --dry-run) DRY_RUN=1 ;;
+        -*) echo "Usage: $0 <version> [--dry-run]" >&2; exit 64 ;;
+        *)
+            if [ -n "${VERSION}" ]; then
+                echo "Usage: $0 <version> [--dry-run]" >&2; exit 64
+            fi
+            VERSION="${arg}"
+            ;;
+    esac
+done
+[ -n "${VERSION}" ] || { echo "Usage: $0 <version> [--dry-run]" >&2; exit 64; }
+
+fail() { echo "✗ $*" >&2; exit 1; }
+step() { echo "▸ $*"; }
+
+# --- Preconditions ------------------------------------------------------------------------
+# Every one of these has a failure mode that is worse to discover after the tag is pushed.
+
+# Dotted integers only: `VersionCompare` in the app parses exactly this shape, and anything
+# else (a `v` prefix, a `-beta` suffix) compares in ways the updater does not intend.
+echo "${VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+)*$' \
+    || fail "version must be dotted integers, e.g. 0.3.0 — got '${VERSION}'"
+
+CURRENT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${PLIST}")"
+CURRENT_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "${PLIST}")"
+
+# Same comparison the app makes, so the script can't approve a release the updater would
+# refuse to install.
+version_gt() {
+    local IFS=.
+    local -a a=($1) b=($2)
+    local i x y
+    for ((i = 0; i < ${#a[@]} || i < ${#b[@]}; i++)); do
+        x=${a[i]:-0}; y=${b[i]:-0}
+        ((10#$x > 10#$y)) && return 0
+        ((10#$x < 10#$y)) && return 1
+    done
+    return 1
+}
+version_gt "${VERSION}" "${CURRENT}" \
+    || fail "${VERSION} is not newer than the current ${CURRENT}; the updater would refuse it"
+
+[ -z "$(git status --porcelain)" ] \
+    || fail "working tree is dirty — commit or stash first, so the release diff is only the release"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "${BRANCH}" = "master" ] \
+    || fail "on '${BRANCH}', not master — releases are cut from master"
+
+git fetch -q origin master
+[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" ] \
+    || fail "master is not in sync with origin/master — pull or push first"
+
+# An empty Unreleased section means there is nothing to release, and would silently produce a
+# version heading with no entries under it.
+UNRELEASED_ENTRIES="$(awk '/^## \[Unreleased\]/{f=1; next} /^## \[/{f=0} f && /^- /' "${CHANGELOG}" | wc -l | tr -d ' ')"
+[ "${UNRELEASED_ENTRIES}" -gt 0 ] \
+    || fail "CHANGELOG has no entries under [Unreleased] — nothing to release"
+
+NEXT_BUILD=$((CURRENT_BUILD + 1))
+TODAY="$(date +%Y-%m-%d)"
+
+echo
+echo "  ${CURRENT} (build ${CURRENT_BUILD})  →  ${VERSION} (build ${NEXT_BUILD})"
+echo "  ${UNRELEASED_ENTRIES} changelog entries move under '## [${VERSION}] — ${TODAY}'"
+echo
+
+if [ "${DRY_RUN}" -eq 1 ]; then
+    echo "(dry run — nothing written)"
+    exit 0
+fi
+
+# --- Edits --------------------------------------------------------------------------------
+
+step "Bumping ${PLIST}…"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" "${PLIST}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${NEXT_BUILD}" "${PLIST}"
+
+step "Closing off ${CHANGELOG}…"
+# Insert the new heading directly under [Unreleased]: everything already written falls under
+# it, and [Unreleased] is left empty for the next cycle.
+awk -v ver="${VERSION}" -v today="${TODAY}" '
+    { print }
+    /^## \[Unreleased\]$/ && !done { print ""; print "## [" ver "] — " today; done = 1 }
+' "${CHANGELOG}" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "${CHANGELOG}"
+
+step "Updating ${SITE}…"
+# Only the structured-data field is hardcoded; the visible version tags fetch the latest tag
+# from the GitHub API at page load, so they follow on their own.
+sed -i '' "s/\"softwareVersion\": \"${CURRENT}\"/\"softwareVersion\": \"${VERSION}\"/" "${SITE}"
+grep -q "\"softwareVersion\": \"${VERSION}\"" "${SITE}" \
+    || fail "couldn't update softwareVersion in ${SITE} — is it still there?"
+
+step "Building the DMGs…"
+./Scripts/make-dmg.sh
+
+# --- Verify -------------------------------------------------------------------------------
+# The point of the whole script: prove the artifact actually carries the version being tagged.
+
+BUILT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' MacRazer.app/Contents/Info.plist)"
+[ "${BUILT}" = "${VERSION}" ] \
+    || fail "built app reports ${BUILT}, not ${VERSION} — do not tag this"
+
+for asset in "dist/MacRazer.dmg" "dist/MacRazer-${VERSION}.dmg"; do
+    [ -f "${asset}" ] || fail "expected ${asset} — make-dmg.sh did not produce it"
+done
+
+echo
+echo "✓ ${VERSION} (build ${NEXT_BUILD}) is ready, and the built app agrees."
+echo
+echo "  Review, then:"
+echo "    git diff"
+echo "    git commit -am 'Release v${VERSION}'"
+echo "    git push"
+echo "    git tag v${VERSION} && git push origin v${VERSION}"
+echo "    gh release create v${VERSION} \\"
+echo "      dist/MacRazer.dmg dist/MacRazer-${VERSION}.dmg \\"
+echo "      --title 'v${VERSION}' --notes-from-tag"
+echo
+echo "  Attach BOTH assets: the in-app updater fetches the fixed 'MacRazer.dmg' name, and the"
+echo "  versioned copy is what makes the Releases page self-describing."

--- a/Tests/Scripts/release-test.sh
+++ b/Tests/Scripts/release-test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Tests for the parts of Scripts/release.sh that decide things: the version comparison and the
+# two changelog operations.
+#
+# `bash -n` and shellcheck prove the script parses; they cannot catch two individually-valid
+# regexes that disagree with each other, which is exactly what went wrong once — the guard
+# counted entries under a heading the rewrite then didn't match, so a release could be built
+# and declared ready with its changelog never promoted. These are fixture tests for that class.
+#
+#   ./Tests/Scripts/release-test.sh
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+RELEASE="Scripts/release.sh"
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+bad()  { FAIL=$((FAIL + 1)); echo "  ✗ $1"; echo "      expected: $2"; echo "      actual:   $3"; }
+check() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "$2" "$3"; }
+
+# The script guards on state (branch, cleanliness) before reaching its logic, so the logic is
+# extracted the same way a caller would read it: by the marker comments around it.
+UNRELEASED_HEADING="$(grep -m1 "^UNRELEASED_HEADING=" "${RELEASE}" | cut -d"'" -f2)"
+[ -n "${UNRELEASED_HEADING}" ] || { echo "couldn't read UNRELEASED_HEADING from ${RELEASE}"; exit 1; }
+
+count_entries() { # <file>
+    awk -v h="${UNRELEASED_HEADING}" '$0 == h {f=1; next} /^## \[/{f=0} f && /^- /' "$1" | wc -l | tr -d ' '
+}
+promote() { # <file> <version> <date>  → stdout, non-zero if nothing matched
+    awk -v ver="$2" -v today="$3" -v h="${UNRELEASED_HEADING}" '
+        { print }
+        $0 == h && !inserted { print ""; print "## [" ver "] — " today; inserted = 1 }
+        END { exit inserted ? 0 : 1 }
+    ' "$1"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+echo "Counting entries under [Unreleased]"
+
+printf '# C\n\n## [Unreleased]\n\n### Added\n- one\n- two\n\n## [0.2.1] — x\n\n### Added\n- old\n' > "${TMP}/two.md"
+check "counts only the unreleased entries" "2" "$(count_entries "${TMP}/two.md")"
+
+printf '# C\n\n## [Unreleased]\n\n## [0.2.1] — x\n\n### Added\n- old\n- older\n' > "${TMP}/empty.md"
+check "an empty section counts zero, not the release below it" "0" "$(count_entries "${TMP}/empty.md")"
+
+# Continuation lines are indented, so only the leading "- " lines are entries.
+printf '# C\n\n## [Unreleased]\n\n### Added\n- one\n continued here\n more\n\n## [0.2.1] — x\n' > "${TMP}/wrap.md"
+check "wrapped entries count once" "1" "$(count_entries "${TMP}/wrap.md")"
+
+echo "Promoting [Unreleased] to a version heading"
+
+promote "${TMP}/two.md" "0.3.0" "2026-09-04" > "${TMP}/out.md"
+check "inserts the new heading" "1" "$(grep -c '^## \[0.3.0\] — 2026-09-04$' "${TMP}/out.md")"
+check "leaves [Unreleased] empty" "0" "$(count_entries "${TMP}/out.md")"
+check "moves the entries under the new heading" "2" \
+    "$(awk '/^## \[0.3.0\]/{f=1;next} /^## \[0.2.1\]/{f=0} f && /^- /' "${TMP}/out.md" | wc -l | tr -d ' ')"
+check "keeps the previous release intact" "1" \
+    "$(awk '/^## \[0.2.1\]/{f=1;next} /^## \[/{f=0} f && /^- /' "${TMP}/out.md" | wc -l | tr -d ' ')"
+check "loses no lines but the two it adds" "2" \
+    "$(( $(wc -l < "${TMP}/out.md") - $(wc -l < "${TMP}/two.md") ))"
+
+# The regression this suite exists for: the guard and the rewrite must agree about what an
+# [Unreleased] heading is. They once didn't, and a decorated heading slipped between them.
+printf '# C\n\n## [Unreleased] (next)\n\n### Added\n- one\n\n## [0.2.1] — x\n' > "${TMP}/decorated.md"
+DECORATED_COUNT="$(count_entries "${TMP}/decorated.md")"
+promote "${TMP}/decorated.md" "0.3.0" "2026-09-04" > /dev/null 2>&1
+DECORATED_PROMOTED=$?
+if [ "${DECORATED_COUNT}" -gt 0 ] && [ "${DECORATED_PROMOTED}" -ne 0 ]; then
+    bad "guard and rewrite agree on what a heading is" \
+        "both accept or both reject" "guard counted ${DECORATED_COUNT}, rewrite refused"
+else
+    ok "guard and rewrite agree on what a heading is"
+fi
+
+# A missing section must fail loudly rather than print the file unchanged and exit 0.
+printf '# C\n\n## [0.2.1] — x\n\n### Added\n- old\n' > "${TMP}/none.md"
+promote "${TMP}/none.md" "0.3.0" "2026-09-04" > /dev/null 2>&1
+check "a missing [Unreleased] is an error, not a silent no-op" "1" "$?"
+
+echo "Comparing versions"
+
+# Sourced rather than reimplemented — a copy here could drift from the script exactly as the
+# script could drift from VersionCompare.
+eval "$(awk '/^version_gt\(\)/,/^}/' "${RELEASE}")"
+newer() { version_gt "$1" "$2" && echo yes || echo no; }
+
+check "0.3.0 > 0.2.1"      "yes" "$(newer 0.3.0 0.2.1)"
+check "0.2.2 > 0.2.1"      "yes" "$(newer 0.2.2 0.2.1)"
+check "0.2.10 > 0.2.9"     "yes" "$(newer 0.2.10 0.2.9)"   # not a string compare
+check "1.0.0 > 0.9.9"      "yes" "$(newer 1.0.0 0.9.9)"
+check "0.2.1 == 0.2.1"     "no"  "$(newer 0.2.1 0.2.1)"
+check "0.2.0 < 0.2.1"      "no"  "$(newer 0.2.0 0.2.1)"
+check "0.2.9 < 0.2.10"     "no"  "$(newer 0.2.9 0.2.10)"
+check "0.2 == 0.2.0"       "no"  "$(newer 0.2 0.2.0)"      # trailing zero, same as VersionCompare
+check "0.3 > 0.2.9"        "yes" "$(newer 0.3 0.2.9)"
+check "0.2.08 > 0.2.7"     "yes" "$(newer 0.2.08 0.2.7)"   # leading zero isn't octal
+
+echo
+if [ "${FAIL}" -eq 0 ]; then
+    echo "✓ ${PASS} passed"
+else
+    echo "✗ ${FAIL} failed, ${PASS} passed"
+    exit 1
+fi


### PR DESCRIPTION
The version lives in **three** places and the changelog in a fourth, and they have to agree.

That was cosmetic until this cycle. Now the in-app updater compares the GitHub tag against the running bundle's own version — so a release tagged `v0.3.0` whose bundle still says `0.2.1` leaves every user with **an update badge they can never clear**: the app installs the update, still reports the old version, and finds the same release "newer" on the next check. `UpdateInstaller`'s newer-than guard stops it looping, so it fails safe, but the badge stays forever.

`./Scripts/release.sh 0.3.0` does the four edits, builds both DMGs, and then **checks the built app reports the version being tagged** — which is the point, since that's the thing that goes wrong.

## Refuses before writing anything if

- the version isn't dotted integers (`v0.3.0`, `0.3.0-beta` — shapes `VersionCompare` parses in ways the updater doesn't intend)
- it isn't newer than the current one, **using the same comparison the app makes**, so the script can't approve a release the updater would reject
- the working tree is dirty, HEAD isn't master, or master is out of sync with origin
- `[Unreleased]` is empty — which would otherwise produce a version heading with nothing under it

## Stops before publishing

It prints `git commit`, `git tag` and `gh release create` rather than running them. The error-prone part is keeping four files in sync; the irreversible part stays a deliberate step after reading the diff. `--dry-run` shows the plan without touching anything.

## Verified end-to-end

On a throwaway clone of master, not by inspection:

- every guard refuses as intended, with the right exit codes (64 for usage, 1 for a rejected release)
- an empty `[Unreleased]` counts 0 entries rather than picking up the previous release's
- a real `0.3.0` run changed **exactly three files** (+5/-3): both plist keys, `softwareVersion` in `docs/index.html`, and one inserted changelog heading
- all **34** entries moved under `## [0.3.0] — 2026-09-04`, leaving `[Unreleased]` empty
- both DMGs produced, and the built app reported `0.3.0`

CONTRIBUTING gains a "Cutting a release" section explaining why the versions have to agree.