### PR TITLE
Follow-ups to the Basilisk V3 X contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Fixed
+- **The brightness LED id can no longer be forgotten.** `setBrightness`/`getBrightness` still
+ defaulted `led:` to the Cobra family's `LOGO_LED` — which is precisely the bug the per-model
+ registry field was added to fix, and it failed silently: the mouse answers FAILURE, nothing
+ surfaces, the slider just does nothing. Every call site already passed the id explicitly, so
+ the parameter is now required and the next one can't reproduce it without a compiler error.
+- The `brightness` probe no longer retries a refusal. A FAILURE for a given model and LED is
+ deterministic, so `sendWithRetry` was asking three times 150ms apart — on a model where three
+ of four groups refuse, nine round trips and most of a second of backoff in a diagnostic whose
+ whole job is to report which group answered.
+- The probe's error message said "probe failed" for what can only be a failed *write*: the
+ sweep handles its own refusals per LED, so the outer catch is reachable only by the optional
+ SET.
+- `ZERO_LED` is a named constant alongside the other three, rather than a bare `0x00` in the
+ middle of a list of names.
+- The Basilisk V3 X entry no longer claims its 18000 DPI ceiling was hardware-verified — that
+ figure is the vendor spec, and the reporter exercised DPI at 6400. Everything else in the
+ entry was measured on a device.
+
 ### Added
 - **Razer Basilisk V3 X HyperSpeed support** (PID `0x00B9`), verified on hardware over the
  2.4 GHz dongle: battery, DPI, the onboard DPI stage table, polling rate, lighting effects

--- a/Sources/MacRazer/RazerCommands.swift
+++ b/Sources/MacRazer/RazerCommands.swift
@@ -28,6 +28,10 @@ enum Razer {
     static let backlightLed: UInt8 = 0x05
     static let logoLed: UInt8 = 0x04
     static let scrollLed: UInt8 = 0x01
+    /// "All zones as one" for the effect commands — and, on no model yet seen, for
+    /// brightness. Named so the `brightness` probe's sweep reads as a set of constants
+    /// rather than three names and a literal.
+    static let zeroLed: UInt8 = 0x00
 }
 
 /// RGB triple.
@@ -240,9 +244,14 @@ enum RazerCommands {
     /// NOTE: brightness lives on a different LED group than the effect commands, and which
     /// group varies per model — the Cobra HyperSpeed answers only on LOGO_LED (0x04), the
     /// Basilisk V3 X HyperSpeed only on SCROLL_LED (0x01), and every other group returns
-    /// status 0x03 (failure). Callers pass the model's id from `RazerDevices.brightnessLed`;
-    /// the LOGO_LED default here is the Cobra-family value. Both verified on hardware.
-    static func setBrightness(_ value: UInt8, led: UInt8 = Razer.logoLed) -> RazerReport {
+    /// status 0x03 (failure). Both verified on hardware.
+    ///
+    /// `led` is deliberately required rather than defaulted to the Cobra family's value: a
+    /// hardcoded LOGO_LED is exactly the bug this parameter was added to fix, and it failed
+    /// silently — the device refuses, nothing surfaces, the slider simply does nothing. A
+    /// default would let the next call site reproduce that without a compiler error. Pass
+    /// `RazerDevices.brightnessLed(pid:)`, which falls back to LOGO_LED for unknown models.
+    static func setBrightness(_ value: UInt8, led: UInt8) -> RazerReport {
         var r = RazerReport(commandClass: 0x0F, commandId: 0x04, dataSize: 0x03)
         r.arguments[0] = Razer.varstore
         r.arguments[1] = led
@@ -252,7 +261,7 @@ enum RazerCommands {
 
     /// razer_chroma_extended_matrix_get_brightness(VARSTORE, LOGO_LED)
     ///   get_razer_report(0x0F, 0x84, 0x03). Response args[2] = brightness (0–255).
-    static func getBrightness(led: UInt8 = Razer.logoLed) -> RazerReport {
+    static func getBrightness(led: UInt8) -> RazerReport {
         var r = RazerReport(commandClass: 0x0F, commandId: 0x84, dataSize: 0x03)
         r.arguments[0] = Razer.varstore
         r.arguments[1] = led

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -87,7 +87,12 @@ enum RazerDevices {
         .init(pid: 0x0062, name: "Razer Atheris", fullySupported: true, hasBattery: true, hasLighting: false, maxDPI: 7200, transactionId: 0x1f, matrixTransactionId: 0x1f, connection: .wirelessDongle, silhouette: .atheris, dischargeCurveModelKey: nil),
         // Basilisk V3 X HyperSpeed: AA-cell wireless (2.4 GHz dongle or Bluetooth — no
         // charging, so `is_charging` is always false). Scroll-wheel-only lighting. 0x1f
-        // everywhere per razermouse_driver.c; hardware-verified with this app.
+        // everywhere per razermouse_driver.c.
+        //
+        // Hardware-verified with this app: battery, DPI read/write, the stage table, polling
+        // rate, lighting effects, and brightness on SCROLL_LED. The 18000 ceiling is the
+        // vendor spec — the reporter exercised DPI at 6400, so the top of the range is the
+        // one field here not demonstrated on a device.
         .init(pid: 0x00B9, name: "Razer Basilisk V3 X HyperSpeed", fullySupported: true, hasBattery: true, hasLighting: true, maxDPI: 18000, transactionId: 0x1f, matrixTransactionId: 0x1f, brightnessLed: Razer.scrollLed, connection: .wirelessDongle, silhouette: .cobra, dischargeCurveModelKey: nil),
         // Basilisk X HyperSpeed: the older AA-cell sibling — no lighting at all, and
         // razermouse_driver.c gives it 0xFF for every command it supports. Not verified

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -368,9 +368,14 @@ case "brightness":
         // scroll wheel and answers 0x03 for LOGO), so this must not abort the sweep: the
         // whole point is to discover which LEDs answer on a model we don't know yet.
         for (name, led) in [("LOGO", Razer.logoLed), ("SCROLL", Razer.scrollLed),
-                            ("ZERO", UInt8(0x00)), ("BACKLIGHT", Razer.backlightLed)] {
+                            ("ZERO", Razer.zeroLed), ("BACKLIGHT", Razer.backlightLed)] {
             do {
-                let rr = try dev.sendWithRetry(RazerCommands.getBrightness(led: led))
+                // `send`, not `sendWithRetry`: a FAILURE (0x03) for a given model and LED is
+                // deterministic — the same answer three times, 150ms apart. Retrying it turns
+                // a four-group sweep on a model where three refuse into nine round trips and
+                // most of a second of pure backoff, in a diagnostic whose whole job is to
+                // report which group answered.
+                let rr = try dev.send(RazerCommands.getBrightness(led: led))
                 print("GET brightness (led \(name)=0x\(String(format: "%02x", led))): \(dump(rr))"
                       + " → \(RazerCommands.brightnessPercent(fromRaw: rr.arguments[2]))%")
             } catch {
@@ -379,6 +384,8 @@ case "brightness":
         }
         if let arg = args.dropFirst().first, let pct = Int(arg) {
             let led = RazerDevices.brightnessLed(pid: dev.productID)
+            // Deliberately outside the sweep's per-LED catch: a refusal here is a real
+            // failure to report, not a group that simply doesn't answer.
             let raw = RazerCommands.brightnessRaw(fromPercent: pct)
             print("SET brightness \(pct)% (raw \(raw)) on led 0x\(String(format: "%02x", led)) …")
             let sr = try dev.sendWithRetry(RazerCommands.setBrightness(raw, led: led))
@@ -387,7 +394,9 @@ case "brightness":
             print("  read-back: \(dump(back)) → \(RazerCommands.brightnessPercent(fromRaw: back.arguments[2]))%")
         }
     } catch {
-        print("Brightness probe failed: \(error)")
+        // The sweep above handles its own refusals per LED, so only the optional write can
+        // reach this — saying "probe failed" would point at the part that just succeeded.
+        print("Brightness write failed: \(error)")
         printPermissionHintIfDenied(error)
         exit(2)
     }

--- a/Tests/MacRazerTests/RazerDevicesTests.swift
+++ b/Tests/MacRazerTests/RazerDevicesTests.swift
@@ -74,6 +74,34 @@ final class RazerDevicesTests: XCTestCase {
         XCTAssertNil(RazerDevices.dischargeCurveModelKey(pid: 0x0083))
     }
 
+    /// `testBrightnessLedPerModel` checks the lookup in isolation; this checks the
+    /// composition — registry lookup fed into the command builder — actually lands the
+    /// model's id in `arguments[1]`, the byte the mouse reads. Verified non-vacuous by
+    /// removing `brightnessLed` from the Basilisk entry: it fails with 4 != 1.
+    ///
+    /// What neither test can reach is `MouseController` passing the right pid in the first
+    /// place, which is where the original bug lived — that needs a device. Making `led:`
+    /// a required parameter is what actually guards that: a call site can no longer fall
+    /// back to LOGO_LED by saying nothing.
+    func testBrightnessCommandsCarryTheModelsLed() {
+        func setLed(_ pid: Int?) -> UInt8 {
+            RazerCommands.setBrightness(128, led: RazerDevices.brightnessLed(pid: pid)).arguments[1]
+        }
+        func getLed(_ pid: Int?) -> UInt8 {
+            RazerCommands.getBrightness(led: RazerDevices.brightnessLed(pid: pid)).arguments[1]
+        }
+        // Cobra HyperSpeed — the family the old hardcoded value happened to suit.
+        XCTAssertEqual(setLed(0x00DB), Razer.logoLed)
+        XCTAssertEqual(getLed(0x00DB), Razer.logoLed)
+        // Basilisk V3 X HyperSpeed: scroll wheel only. Sending LOGO here is the silent
+        // no-op — the mouse answers FAILURE and the slider does nothing.
+        XCTAssertEqual(setLed(0x00B9), Razer.scrollLed)
+        XCTAssertEqual(getLed(0x00B9), Razer.scrollLed)
+        // Unknown model, and no device at all, both fall back to the Cobra family's id.
+        XCTAssertEqual(setLed(0x9999), Razer.logoLed)
+        XCTAssertEqual(setLed(nil), Razer.logoLed)
+    }
+
     func testConnectionKind() {
         XCTAssertEqual(RazerDevices.connection(pid: 0x00DB), .wirelessDongle)
         XCTAssertEqual(RazerDevices.connection(pid: 0x00DA), .wired)


### PR DESCRIPTION
The follow-ups promised in the review of #5, kept out of that PR so it could land.

## The one that matters

`setBrightness`/`getBrightness` still defaulted `led:` to the Cobra family's `LOGO_LED`. **That default is the bug #5 fixed** — a hardcoded LOGO_LED made the brightness slider a silent no-op on a scroll-wheel-only mouse: the device answers FAILURE, nothing surfaces, the control just does nothing. Leaving the default in place meant the next call site that forgot the argument would reproduce it exactly, silently, on precisely the models the registry field exists for.

Every call site already passed it explicitly — the build is clean with the defaults removed, which proves it. So the parameter is now required.

**This structural guard matters more than the test below**, because the original defect lived in a `MouseController` call site that no unit test can reach without a device abstraction we don't have.

## The test, and what it doesn't cover

#5 added `testBrightnessLedPerModel`, which asserts the *lookup* returns `0x01`. It would pass unchanged if `MouseController` still sent `LOGO_LED` — the regression that actually mattered.

The new test asserts the composition the app performs (registry lookup → command builder) lands the model's id in `arguments[1]`, the byte the mouse reads. **Verified non-vacuous**: removing `brightnessLed` from the Basilisk entry makes it fail with `4 != 1`.

Its doc comment says plainly what it still can't reach, rather than implying more coverage than it has.

## Smaller

- **The probe no longer retries refusals.** A FAILURE for a given model and LED is deterministic, but it went through `sendWithRetry` — three attempts, 150ms apart. On a model where three of four groups refuse that's nine round trips and most of a second of pure backoff, in a diagnostic whose only job is to report which group answered. `sendWithRetry`'s semantics are untouched for everything else; only the probe changed.
- **The outer catch said "probe failed"** for what can only be a failed *write* — the sweep handles its own refusals per LED.
- **`ZERO_LED` is a named constant** alongside the three it sat next to as a bare `0x00`.
- **The Basilisk entry no longer claims its 18000 DPI ceiling was hardware-verified.** That figure is the vendor spec; the reporter exercised DPI at 6400. Everything else in the entry was measured. `maxDPI` clamps the slider, so the distinction is worth keeping honest.

## Not included

The AA-cell observation from the review — these mice feed `ChargeCycleHistory`, which assumes recharging, so a cell swap logs as a charge cycle and the usage graph offers "time since last full charge" for a mouse that is never charged. Nothing breaks, but it wants a `rechargeable` flag and UI gating, which is a feature rather than a follow-up.

`swift build` clean, **105 tests** pass.