### PR TITLE
Fold duplicate changelog headings, refresh the site copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Fixed
+- The changelog no longer carries duplicate `### Added` / `### Fixed` headings under a single
+ release. Three stacked branches each grew their own section under `[Unreleased]`, and merging
+ them through GitHub appended rather than folded — so `[0.3.0]` shipped with two `### Added`
+ blocks, in the section the release notes link to. Both are folded, with every entry kept.
+- The site's four description fields (meta, Open Graph, Twitter, structured data) still
+ described a 0.2.x app. They now mention that it starts at login and installs its own updates
+ — the two things 0.3.0 added that a reader deciding whether to download would care about.
+
+### Fixed
 - **The brightness LED id can no longer be forgotten.** `setBrightness`/`getBrightness` still
  defaulted `led:` to the Cobra family's `LOGO_LED` — which is precisely the bug the per-model
  registry field was added to fix, and it failed silently: the mouse answers FAILURE, nothing
@@ -25,6 +34,17 @@ expect rough edges until 1.0.
  figure is the vendor spec, and the reporter exercised DPI at 6400. Everything else in the
  entry was measured on a device.
 
+- **The brightness slider now works on mice whose only lit zone is the scroll wheel.** The LED
+ group for brightness was hardcoded to `LOGO_LED`, which the Basilisk V3 X HyperSpeed answers
+ with FAILURE (`0x03`), so dragging the slider silently did nothing on it. Effects and
+ brightness live on different LED groups, and which group answers varies per model, so the id
+ is now a per-model registry field defaulting to the Cobra family's `LOGO_LED` — an unknown
+ mouse behaves exactly as before.
+- **The `brightness` CLI probe no longer stops at the first LED group that refuses.** It exists
+ to discover which group a new model answers on, but a `LOGO_LED` refusal threw before the
+ sweep started — precisely the case it was written for. It now reports LOGO, SCROLL, ZERO and
+ BACKLIGHT individually, so a new model's brightness LED can be found in one run.
+
 ### Added
 - **Razer Basilisk V3 X HyperSpeed support** (PID `0x00B9`), verified on hardware over the
  2.4 GHz dongle: battery, DPI, the onboard DPI stage table, polling rate, lighting effects
@@ -38,18 +58,6 @@ expect rough edges until 1.0.
  lighting at all, a 16000 DPI ceiling, and `0xFF` transaction ids rather than the Cobra
  family's `0x1f`. Nobody has run it against hardware yet, so it stays marked unverified: the
  app will attempt its controls without claiming they work.
-
-### Fixed
-- **The brightness slider now works on mice whose only lit zone is the scroll wheel.** The LED
- group for brightness was hardcoded to `LOGO_LED`, which the Basilisk V3 X HyperSpeed answers
- with FAILURE (`0x03`), so dragging the slider silently did nothing on it. Effects and
- brightness live on different LED groups, and which group answers varies per model, so the id
- is now a per-model registry field defaulting to the Cobra family's `LOGO_LED` — an unknown
- mouse behaves exactly as before.
-- **The `brightness` CLI probe no longer stops at the first LED group that refuses.** It exists
- to discover which group a new model answers on, but a `LOGO_LED` refusal threw before the
- sweep started — precisely the case it was written for. It now reports LOGO, SCROLL, ZERO and
- BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ## [0.3.0] — 2026-09-07
 
@@ -69,7 +77,6 @@ expect rough edges until 1.0.
  comparison and both changelog operations, and CI runs it — `bash -n` and shellcheck prove a
  script parses, not that two of its patterns agree with each other.
 
-### Added
 - **An About window**, first in the menu bar's right-click menu, where macOS puts About. Version and build, the
  developer, and the three things this app actually owes the person reading it: that it is
  **not affiliated with Razer Inc.** and uses their marks only to describe compatibility; that

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="google-site-verification" content="SmhAFHV4KG5IkP0GP-oTNQpCV6aW-Dp_afW9zDSs5NA" />
 <title>MacRazer: Razer mouse control for macOS (free, open source)</title>
-<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Works with Razer Cobra HyperSpeed, Basilisk V3 X HyperSpeed, Atheris, and Cobra Pro.">
+<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Starts at login and installs its own updates. Works with Razer Cobra HyperSpeed, Basilisk V3 X HyperSpeed, Atheris, and Cobra Pro.">
 <meta name="keywords" content="Razer mouse macOS, Razer Synapse alternative Mac, Razer Cobra HyperSpeed Mac, Razer Atheris Mac, Razer mouse driver macOS, Razer DPI macOS, Razer RGB macOS">
 <meta name="author" content="SorcRR">
 <link rel="canonical" href="https://sorcrr.github.io/MacRazer/">
@@ -14,13 +14,13 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://sorcrr.github.io/MacRazer/">
 <meta property="og:title" content="MacRazer: Razer mouse control for macOS">
-<meta property="og:description" content="Free, open-source menu bar app for Razer mice on macOS: battery, DPI, RGB, polling rate, and button remapping over USB HID. No Synapse required.">
+<meta property="og:description" content="Free, open-source menu bar app for Razer mice on macOS: battery, DPI, RGB, polling rate, and button remapping over USB HID. No Synapse required, and it keeps itself up to date.">
 <meta property="og:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
 
 <!-- Twitter / X card -->
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="MacRazer: Razer mouse control for macOS">
-<meta name="twitter:description" content="Free, open-source menu bar app for Razer mice on macOS: battery, DPI, RGB, polling rate, and button remapping over USB HID. No Synapse required.">
+<meta name="twitter:description" content="Free, open-source menu bar app for Razer mice on macOS: battery, DPI, RGB, polling rate, and button remapping over USB HID. No Synapse required, and it keeps itself up to date.">
 <meta name="twitter:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
 
 <link rel="icon" type="image/png" href="assets/favicon.png">
@@ -35,7 +35,7 @@
   "name": "MacRazer",
   "operatingSystem": "macOS 14+",
   "applicationCategory": "UtilitiesApplication",
-  "description": "A native menu bar app to control Razer mice on macOS: battery, DPI, RGB lighting, polling rate, and button remapping over USB HID, without Razer Synapse.",
+  "description": "A native menu bar app to control Razer mice on macOS: battery, DPI, RGB lighting, polling rate, and button remapping over USB HID, without Razer Synapse. Starts at login and installs its own updates.",
   "url": "https://sorcrr.github.io/MacRazer/",
   "downloadUrl": "https://github.com/SorcRR/MacRazer/releases/latest/download/MacRazer.dmg",
   "softwareVersion": "0.3.0",


### PR DESCRIPTION
## The changelog

`[0.3.0]` shipped with **two `### Added` headings**, and `[Unreleased]` had picked up a second `### Fixed`. Three stacked branches each grew their own sections under `[Unreleased]`, and merging them through GitHub appended rather than folded — the earlier merges I resolved by hand got folded, the ones GitHub merged cleanly did not.

It's cosmetic, but it's in the section the [v0.3.0 release notes](https://github.com/SorcRR/MacRazer/releases/tag/v0.3.0) link to.

Both folded, verified rather than eyeballed:

- **146 entries before, 146 after**, sorted entry sets identical
- release headings byte-identical
- zero duplicate headings anywhere in the file, not just the two known ones

## The homepage — less was wrong than I expected

Already correct, no change needed:

- `softwareVersion` is `0.3.0` — the release script handles it
- the visible version tags fetch the latest tag from the GitHub API at page load, so they follow releases on their own
- the supported-mice table matches the registry exactly, including @joelday's Basilisk entries
- OpenRazer is credited in the footer

**What was stale: all four description fields** — `meta`, `og:`, `twitter:`, and the JSON-LD `description`. Every one described a 0.2.x app: battery, DPI, RGB, polling, remapping. None mentioned the two things 0.3.0 added that someone deciding whether to download would care about. They now say it starts at login and installs its own updates.

HTML still parses and the structured data is still valid JSON.

## What I left alone, deliberately

**The 8-card feature grid.** It's four columns, so eight cards are two clean rows and a ninth leaves a ragged one — the same reason the About window's content went into the Install section rather than getting its own card. Login and self-installing updates are already covered in install step 3.

Padding to twelve would mean inventing four features, and "Settings window" and "About window" are UI containers rather than things to sell.