### PR TITLE
Guard the changelog structure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       # test catches.
       - name: Test shell scripts
         run: ./Tests/Scripts/release-test.sh
+      # Duplicate headings arrive by clean merge, so nothing conflicts and no reviewer sees
+      # them — this is the only thing that will.
+      - name: Check changelog structure
+        run: ./Tests/Scripts/changelog-test.sh
       - name: Build
         run: swift build
       - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ expect rough edges until 1.0.
 ## [Unreleased]
 
 ### Fixed
+- **The changelog can no longer accumulate duplicate headings unnoticed.** Two branches each
+ adding a `### Fixed` under `[Unreleased]` merge cleanly — git appends, nothing conflicts, and
+ nobody spots it in a diff. It happened three times across one stack, and then again in the PR
+ that folded those three: the fold ran, and the entry describing it was prepended above the
+ section it had just merged. `Tests/Scripts/changelog-test.sh` now checks the structure on
+ every PR, so the fix is a check rather than a habit.
 - The changelog no longer carries duplicate `### Added` / `### Fixed` headings under a single
  release. Three stacked branches each grew their own section under `[Unreleased]`, and merging
  them through GitHub appended rather than folded — so `[0.3.0]` shipped with two `### Added`
@@ -15,7 +21,6 @@ expect rough edges until 1.0.
  described a 0.2.x app. They now mention that it starts at login and installs its own updates
  — the two things 0.3.0 added that a reader deciding whether to download would care about.
 
-### Fixed
 - **The brightness LED id can no longer be forgotten.** `setBrightness`/`getBrightness` still
  defaulted `led:` to the Cobra family's `LOGO_LED` — which is precisely the bug the per-model
  registry field was added to fix, and it failed silently: the mouse answers FAILURE, nothing

--- a/Tests/Scripts/changelog-test.sh
+++ b/Tests/Scripts/changelog-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Guards the changelog's structure. Runs in CI on every PR.
+#
+# This exists because folding duplicate headings by hand does not stick. Sections accumulate
+# them whenever two branches each add, say, a `### Fixed` under `[Unreleased]` and both get
+# merged — git appends cleanly, so nothing conflicts and nothing complains. It happened three
+# times across one stack, and then again in the very PR that folded the first three: the fold
+# ran, and the entry describing the fold was prepended above the section it had just merged.
+#
+# A person cannot reliably notice this in a diff. A check can.
+#
+#   ./Tests/Scripts/changelog-test.sh
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+CHANGELOG="CHANGELOG.md"
+FAIL=0
+
+fail() { FAIL=$((FAIL + 1)); echo "  ✗ $1"; }
+ok()   { echo "  ✓ $1"; }
+
+echo "Checking ${CHANGELOG}"
+
+# 1. No release section may repeat a `### ` heading. Keep a Changelog groups entries under one
+#    heading per kind; two `### Fixed` in a release is a merge artefact, not a structure.
+DUPES="$(awk '
+    /^## \[/ { section = $0; delete seen; next }
+    /^### / { if (seen[$0]++) print section " → " $0 }
+' "${CHANGELOG}")"
+if [ -n "${DUPES}" ]; then
+    fail "duplicate headings within a release section:"
+    echo "${DUPES}" | sed 's/^/      /'
+    echo "      fold the later block's entries into the first heading of that kind."
+else
+    ok "no release section repeats a heading"
+fi
+
+# 2. Every entry must sit under a `### ` heading. A bullet directly under `## [x.y.z]` renders
+#    outside any category and is invisible to anything that parses the file by section.
+ORPHANS="$(awk '
+    /^## \[/ { section = $0; kind = ""; next }
+    /^### /  { kind = $0; next }
+    /^- /    { if (kind == "") print section " → " substr($0, 1, 60) "..." }
+' "${CHANGELOG}")"
+if [ -n "${ORPHANS}" ]; then
+    fail "entries not under any ### heading:"
+    echo "${ORPHANS}" | sed 's/^/      /'
+else
+    ok "every entry sits under a heading"
+fi
+
+# 3. `## [Unreleased]` must exist: Scripts/release.sh promotes it by exact match, and without
+#    it a release would bump the versions and quietly ship no changelog section at all.
+if grep -qx '## \[Unreleased\]' "${CHANGELOG}"; then
+    ok "[Unreleased] heading present and exactly matched"
+else
+    fail "no line reading exactly '## [Unreleased]' — Scripts/release.sh needs it to promote"
+fi
+
+echo
+if [ "${FAIL}" -eq 0 ]; then
+    echo "✓ changelog structure is sound"
+else
+    echo "✗ ${FAIL} problem(s)"
+    exit 1
+fi


### PR DESCRIPTION
#13 folded three duplicate headings by hand — and then introduced a fourth. The fold ran, and the changelog entry *describing the fold* was prepended above the section it had just merged. Master ended up with a duplicate `### Fixed` under `[Unreleased]` minutes after the PR that existed to remove duplicates.

That's the argument for a check rather than a habit. These arrive by **clean merge**: two branches each add a `### Fixed`, git appends, nothing conflicts, nothing warns, and no reviewer spots it in a diff. Folding by hand fixes the instance and does nothing about the mechanism — the same shallow-fix pattern the earlier reviews kept catching.

## What the check asserts

`Tests/Scripts/changelog-test.sh`, on every PR:

1. **No release section repeats a `### ` heading** — the actual bug, four times now.
2. **Every entry sits under a heading.** A bullet directly under `## [x.y.z]` renders outside any category and is invisible to anything parsing by section.
3. **`## [Unreleased]` exists exactly as written.** `Scripts/release.sh` promotes it by exact match; without it a release would bump every version and ship no changelog section at all — and the release script's own guard would pass, since it counts entries under a heading that isn't there.

## Verified by injecting each fault

Not by reading it:

| injected | exit |
|---|---|
| duplicate `### Fixed` | 1 ✓ |
| entry with no heading | 1 ✓ |
| `[Unreleased]` renamed | 1 ✓ |
| restored | 0 ✓ |

It also reported the live duplicate on master before the fold, which is how it was found.

## Also

Folds the duplicate #13 left behind. 149 entries, one net new (this PR's own), nothing lost.