### PR TITLE
Say what has actually been verified on each mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Changed
+- **The supported-mice tables say what was actually verified, and by whom.** README, the site
+ and `DOCUMENTATION.md` listed nine devices while the registry carried twelve, and the three
+ tiers ("Tested, works best" / "user-reported" / "not verified") gave the same label to the
+ development mouse and to a model one contributor ran once. The tables now name the commands
+ each mouse has been probed with and credit whoever ran them, so "verified" means someone
+ posted the output rather than that a protocol table says it should work. Unverified rows say
+ so plainly, with a note that an unverified mouse is not a broken one.
+
 ### Fixed
 - **The changelog can no longer accumulate duplicate headings unnoticed.** Two branches each
  adding a `### Fixed` under `[Unreleased]` merge cleanly — git appends, nothing conflicts, and

--- a/README.md
+++ b/README.md
@@ -49,15 +49,25 @@ the mouse connects, disconnects, or sleeps.
 
 ## Supported mice
 
-| Mouse | Status |
-|---|---|
-| Razer Cobra HyperSpeed (wired + wireless) | Tested, works best |
-| Razer Atheris | Tested, works best |
-| Razer Basilisk V3 X HyperSpeed | Tested, works best |
-| Razer Basilisk V3 | In the registry; user-reported working |
-| Razer Basilisk X HyperSpeed | In the registry; not yet hardware-verified |
-| Razer Cobra, Cobra Pro (wired + wireless) | Same protocol, not yet hardware-verified here |
-| Any other Razer mouse | Detected and named; should work, but untested |
+"Verified" below means someone ran the CLI probes against the mouse and posted the output,
+not that the protocol tables say it should work. Where nobody has, the row says so.
+
+| Mouse | Verified on hardware | By |
+|---|---|---|
+| Razer Cobra HyperSpeed (wired + wireless) | Everything, continuously — the development mouse | maintainer |
+| Razer Atheris | Battery, DPI, polling | maintainer |
+| Razer Basilisk V3 X HyperSpeed | Battery, DPI, DPI stages, polling, lighting, brightness | [@joelday](https://github.com/joelday) |
+| Razer Viper Ultimate (Wireless) | Battery, DPI, polling, brightness | [@raphaelchenouard](https://github.com/raphaelchenouard) |
+| Razer Orochi 2013 | DPI only | [@raphaelchenouard](https://github.com/raphaelchenouard) |
+| Razer Basilisk V3 | Nothing; reported working by a user | — |
+| Razer Cobra, Cobra Pro (wired + wireless) | Nothing; same protocol family, values from OpenRazer | — |
+| Razer Basilisk X HyperSpeed | Nothing; values from OpenRazer | — |
+| Razer Viper Ultimate (Wired) | Nothing; its wireless sibling is verified | — |
+| Any other Razer mouse | Nothing; detected and named, controls attempted | — |
+
+An unverified mouse is not a broken one. Detection and naming work for any Razer mouse, and
+the controls are attempted with values taken from OpenRazer's tables — they usually work. The
+column is about who has actually seen it happen.
 
 Adding a model is a small change to a registry plus on-hardware verification. See
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -2,10 +2,11 @@
 
 A native macOS menu bar app to control Razer mice: battery, DPI, polling rate, RGB lighting,
 brightness, and software button remapping. Razer's Synapse does not support macOS, so this
-app talks to the mouse directly over USB HID. It is tested on, and works best with, the
-Razer Cobra HyperSpeed, the Razer Atheris and the Razer Basilisk V3 X HyperSpeed. By design
-it detects and tries to control any Razer mouse using the same protocol family, but models
-beyond those three are untested.
+app talks to the mouse directly over USB HID. Four models have been verified on real
+hardware: the Razer Cobra HyperSpeed (the development mouse), the Razer Atheris, the Razer
+Basilisk V3 X HyperSpeed and the Razer Viper Ultimate. By design it detects and tries to
+control any Razer mouse in the same protocol family; the registry carries twelve product ids,
+and README's table says which of them anyone has actually run the probes against.
 
 This document explains how the app is built and how every feature works, so a future Claude
 session or a human can pick it up cold. See also:

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="google-site-verification" content="SmhAFHV4KG5IkP0GP-oTNQpCV6aW-Dp_afW9zDSs5NA" />
 <title>MacRazer: Razer mouse control for macOS (free, open source)</title>
-<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Starts at login and installs its own updates. Works with Razer Cobra HyperSpeed, Basilisk V3 X HyperSpeed, Atheris, and Cobra Pro.">
+<meta name="description" content="MacRazer is a free, open-source menu bar app that controls Razer mice on macOS: battery %, DPI, RGB lighting, polling rate, and button remapping over USB HID. No Synapse required, no kernel extension. Starts at login and installs its own updates. Works with Razer Cobra HyperSpeed, Basilisk V3 X HyperSpeed, Viper Ultimate, Atheris, and Cobra Pro.">
 <meta name="keywords" content="Razer mouse macOS, Razer Synapse alternative Mac, Razer Cobra HyperSpeed Mac, Razer Atheris Mac, Razer mouse driver macOS, Razer DPI macOS, Razer RGB macOS">
 <meta name="author" content="SorcRR">
 <link rel="canonical" href="https://sorcrr.github.io/MacRazer/">
@@ -192,36 +192,48 @@
     <h2>Supported mice</h2>
     <table>
       <thead>
-        <tr><th>Mouse</th><th>Status</th></tr>
+        <tr><th>Mouse</th><th>Verified on hardware</th></tr>
       </thead>
       <tbody>
         <tr>
           <td>Razer Cobra HyperSpeed <span class="muted">(wired + wireless)</span></td>
-          <td><span class="badge badge-good">Tested, works best</span></td>
+          <td><span class="badge badge-good">Everything, continuously</span> <span class="muted">the development mouse</span></td>
         </tr>
         <tr>
           <td>Razer Atheris</td>
-          <td><span class="badge badge-good">Tested, works best</span></td>
+          <td><span class="badge badge-good">Battery, DPI, polling</span> <span class="muted">maintainer</span></td>
         </tr>
         <tr>
           <td>Razer Basilisk V3 X HyperSpeed</td>
-          <td><span class="badge badge-good">Tested, works best</span></td>
+          <td><span class="badge badge-good">Battery, DPI, stages, polling, lighting, brightness</span> <span class="muted">@joelday</span></td>
+        </tr>
+        <tr>
+          <td>Razer Viper Ultimate <span class="muted">(wireless)</span></td>
+          <td><span class="badge badge-good">Battery, DPI, polling, brightness</span> <span class="muted">@raphaelchenouard</span></td>
+        </tr>
+        <tr>
+          <td>Razer Orochi 2013</td>
+          <td><span class="badge badge-mid">DPI only</span> <span class="muted">@raphaelchenouard</span></td>
         </tr>
         <tr>
           <td>Razer Basilisk V3</td>
-          <td><span class="badge badge-mid">User‑reported working</span></td>
-        </tr>
-        <tr>
-          <td>Razer Basilisk X HyperSpeed</td>
-          <td><span class="badge badge-mid">Same protocol, not yet verified</span></td>
+          <td><span class="badge badge-mid">Nothing; reported working by a user</span></td>
         </tr>
         <tr>
           <td>Razer Cobra, Cobra Pro <span class="muted">(wired + wireless)</span></td>
-          <td><span class="badge badge-mid">Same protocol, not yet verified</span></td>
+          <td><span class="badge badge-mid">Nothing; values from OpenRazer</span></td>
+        </tr>
+        <tr>
+          <td>Razer Basilisk X HyperSpeed</td>
+          <td><span class="badge badge-mid">Nothing; values from OpenRazer</span></td>
+        </tr>
+        <tr>
+          <td>Razer Viper Ultimate <span class="muted">(wired)</span></td>
+          <td><span class="badge badge-mid">Nothing; its wireless sibling is verified</span></td>
         </tr>
         <tr>
           <td>Any other Razer mouse</td>
-          <td><span class="badge badge-mid">Detected and named; untested</span></td>
+          <td><span class="badge badge-mid">Nothing; detected and named, controls attempted</span></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
The docs listed **nine** devices; the registry carries **twelve**. The Orochi 2013 and both Viper Ultimates were supported in code and absent from README, the site table and `DOCUMENTATION.md`.

## The bigger problem was the tiers

"Tested, works best" covered three devices verified to three very different depths:

| mouse | what anyone has actually run | who |
|---|---|---|
| Cobra HyperSpeed | everything, continuously | the development mouse |
| Atheris | battery, DPI, polling | maintainer |
| Basilisk V3 X | battery, DPI, stages, polling, lighting, brightness | @joelday, once |

Someone deciding whether to trust this with their Basilisk got the same label as the mouse that gets retested on every change. And the Orochi, with exactly one command exercised, would have landed in the same bucket as everything else "in the registry".

The tables now name the commands each mouse has been probed with and credit whoever ran them. **Verified means someone posted the output**, not that OpenRazer's tables say it should work.

Unverified rows say so plainly, with a note that unverified is not broken: detection and naming work for any Razer mouse, and the controls are attempted with OpenRazer's values and usually work. The column is about who has seen it happen.

## Checked, not eyeballed

- **all twelve product ids covered** across ten rows, verified against `RazerDevices.swift` programmatically
- HTML still parses, structured data still valid JSON
- changelog guard passes, 105 tests pass, build clean

Also updated the meta description (it listed the supported mice and omitted the Viper) and the `DOCUMENTATION.md` intro, which still said three models were tested.

## One thing I did not change

The registry marks **Cobra, Cobra Pro (Wired) and Cobra Pro (Wireless) as `fullySupported: true`**, but nobody has verified any of them — the values come from OpenRazer. That flag drives the popover's status line, so those users see "Connected" rather than "Connected · limited support", while these tables now say nothing has been verified.

That contradiction is real and predates this PR. Fixing it means flipping three flags and changing what those users see in the app, which is a behaviour change rather than a docs one, so I've left it for you to call.