### PR TITLE
Show what's in an update before installing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
       # test catches.
       - name: Test shell scripts
         run: ./Tests/Scripts/release-test.sh
+      # The release body is what the app's "What's new" page is built from, so a drafter that
+      # silently drops a contributor or picks up the previous release's entries is a user-
+      # visible bug, not a scripting inconvenience.
+      - name: Test the release-notes drafter
+        run: ./Tests/Scripts/release-notes-test.sh
       # Duplicate headings arrive by clean merge, so nothing conflicts and no reviewer sees
       # them — this is the only thing that will.
       - name: Check changelog structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
+- **The "What's new" summary survives a line wrap.** Every source line above the first
+ heading became its own paragraph, so a summary hard-wrapped across two lines — the house
+ style in every markdown file here, and what the drafted template itself does — showed a
+ blank line through the middle of a sentence.
+
 - **Releases come with a drafted body, and it credits contributors.** The release body is not
  cosmetic any more — the app fetches it and builds the "What's new" page from it — so a
  release published without one makes that page quietly not appear, and a release that forgets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ expect rough edges until 1.0.
  draft still carrying its `TODO:` placeholder, since that would become the release's first
  paragraph. The entries come out verbatim: the script drafts the mechanical parts and leaves
  the writing alone.
+- **A release notes page on the site**, linked from the nav and the footer of every page.
+ Every version and what was in it, built from the same GitHub release bodies the app shows,
+ with the install instructions dropped by the same rule the app uses — someone reading this
+ has plainly managed it. It fetches at page load rather than being generated, so a release
+ appears on the site without the site being touched; if the API is unreachable it says so and
+ points at GitHub instead of sitting on "Loading…". The markdown is turned into DOM nodes
+ rather than HTML strings, so nothing in a release body can become markup on the page.
+
 - **The release notes outlive the update.** They were reachable from one place, the update
  card, which disappears the moment you are on the new version — so the notes went with it,
  and with "Install updates automatically" on you never saw the card in the first place. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ expect rough edges until 1.0.
  draft still carrying its `TODO:` placeholder, since that would become the release's first
  paragraph. The entries come out verbatim: the script drafts the mechanical parts and leaves
  the writing alone.
+- **The release notes outlive the update.** They were reachable from one place, the update
+ card, which disappears the moment you are on the new version — so the notes went with it,
+ and with "Install updates automatically" on you never saw the card in the first place. That
+ setting could take you from 0.3.0 to 0.3.2 without a word about any of it. The first launch
+ on a new version now shows a dismissible **"Updated to 0.3.1"** card in the popover with the
+ same "What's new" row, and the About window keeps a **"What's new in 0.3.1"** link under the
+ version for afterwards. Neither fetches anything: the check that found the release already
+ cached its body, and after the install that release is the one running. The notes are shown
+ only when the cache is demonstrably about the version running, and a first install is not
+ an update — "Updated to 0.3.1" on a first launch would simply be false.
+
 - **The update card says what's in the update.** It offered "Update & Restart" and nothing
  about why you would want to — you were being asked to replace your app on no information,
  which is the thing the macOS convention of showing release notes in the update dialog exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
+- **The update card says what's in the update.** It offered "Update & Restart" and nothing
+ about why you would want to — you were being asked to replace your app on no information,
+ which is the thing the macOS convention of showing release notes in the update dialog exists
+ to prevent. The card now carries one row, `What's new in 0.3.1 ›`, opening a page with the
+ release notes parsed out of the GitHub release body the updater already fetches. One row,
+ because the popover with an update showing is 748pt tall and a menu bar popover has roughly
+ 600-700pt to work with — inline notes would have pushed it past 900. The page repeats
+ Update & Restart at the bottom, so the decision can be made where the information is.
 - **Razer Basilisk V3 X HyperSpeed support** (PID `0x00B9`), verified on hardware over the
  2.4 GHz dongle: battery, DPI, the onboard DPI stage table, polling rate, lighting effects
  and brightness all read and write. Detection and naming already worked for any Razer mouse;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
+- **Releases come with a drafted body, and it credits contributors.** The release body is not
+ cosmetic any more — the app fetches it and builds the "What's new" page from it — so a
+ release published without one makes that page quietly not appear, and a release that forgets
+ a contributor forgets them in the place users actually read. `release.sh` now drafts
+ `dist/RELEASE_NOTES-<version>.md` from the changelog section it just promoted, with a Thanks
+ section built from the merge commits: handle, PR title and number, the maintainer's own
+ merges left out. Squash-merged PRs leave no merge commit to read, so those authors are
+ reported on stderr to be added by hand rather than silently dropped. `--check` refuses a
+ draft still carrying its `TODO:` placeholder, since that would become the release's first
+ paragraph. The entries come out verbatim: the script drafts the mechanical parts and leaves
+ the writing alone.
 - **The update card says what's in the update.** It offered "Update & Restart" and nothing
  about why you would want to — you were being asked to replace your app on no information,
  which is the thing the macOS convention of showing release notes in the update dialog exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,9 @@ expect rough edges until 1.0.
  this release is the awkward case: the version before it never recorded one, so it looks
  exactly like a first install. Evidence that MacRazer has run here before — the update
  check's date, or the login-item default — tells them apart, so the release that introduces
- the card is not the one release that never shows it.
+ the card is not the one release that never shows it. It is written down rather than only
+ held in memory: the card waits for the popover to be opened, which for a menu bar app can be
+ days, and a reboot in between must not swallow it.
 
 - **The update card says what's in the update.** It offered "Update & Restart" and nothing
  about why you would want to — you were being asked to replace your app on no information,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,11 @@ expect rough edges until 1.0.
  version for afterwards. Neither fetches anything: the check that found the release already
  cached its body, and after the install that release is the one running. The notes are shown
  only when the cache is demonstrably about the version running, and a first install is not
- an update — "Updated to 0.3.1" on a first launch would simply be false.
+ an update — "Updated to 0.3.1" on a first launch would simply be false. The upgrade *to*
+ this release is the awkward case: the version before it never recorded one, so it looks
+ exactly like a first install. Evidence that MacRazer has run here before — the update
+ check's date, or the login-item default — tells them apart, so the release that introduces
+ the card is not the one release that never shows it.
 
 - **The update card says what's in the update.** It offered "Update & Restart" and nothing
  about why you would want to — you were being asked to replace your app on no information,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,32 @@ operations; CI runs it. Attach **both** DMGs to the release: the updater fetches
 `MacRazer.dmg` name, and the versioned copy makes the Releases page self-describing.
 `--dry-run` shows what it would do.
 
+### The release body
+
+`release.sh` also drafts one, to `dist/RELEASE_NOTES-<version>.md`. **It is a draft, not the
+finished copy** — it carries every changelog entry verbatim, and the changelog is written for
+contributors. Expect to cut most of it; the published 0.3.0 body was about a fifth the length
+of its changelog section.
+
+The body matters more than it looks: the app fetches it and builds the popover's "What's new"
+page from it, so a release published with no body makes that page quietly not appear. The
+draft fills in the parts that are mechanical and easy to forget:
+
+- every entry in the release, so none is left out by accident
+- **everyone whose PR is in it**, by GitHub handle and PR number, read from the merge commits
+- the Gatekeeper install note and the changelog link
+
+A squash-merged PR leaves no merge commit to read, so its author can't be credited
+automatically — the script says so on stderr and you add them by hand. Before publishing:
+
+```sh
+./Scripts/release-notes.sh --check dist/RELEASE_NOTES-<version>.md
+```
+
+which refuses a draft still carrying the `TODO:` placeholder or with no summary above its
+first heading — either one would end up as the release's first paragraph, which is exactly
+what the app shows.
+
 ## The most valuable contribution: device profiles
 Detection and naming already work for **any** Razer mouse, via the USB product string. What
 has to be verified per model is the **control protocol**. Four models have been checked on

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Razer mice that use the same HID protocol family, but those are untested, so tre
 - **Updates install themselves**: when a new release is out, "Update & Restart" downloads it,
   checks it, replaces the installed app and relaunches — no dragging a DMG. It falls back to
   the plain DMG download when MacRazer is somewhere it can't replace itself (still on the disk
-  image, or in a folder you can't write to).
+  image, or in a folder you can't write to). The card also links to **what's in the release**,
+  so the choice isn't blind.
 
 Settings persist across app restarts and reconnects, and the menu bar updates on its own when
 the mouse connects, disconnects, or sleeps.

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Draft the GitHub release body for a version, printed to stdout.
+#
+#   ./Scripts/release-notes.sh 0.3.1 > dist/RELEASE_NOTES-0.3.1.md
+#   ./Scripts/release-notes.sh 0.3.0 --since v0.2.1   # redo a past one
+#
+# The release body and CHANGELOG.md are different documents for different readers, and the
+# body is the one the app shows: `UpdateChecker` fetches it and the popover's "What's new"
+# page is built from it. So a release published with no body makes that page quietly not
+# appear, and a release that forgets a contributor forgets them in the place users read.
+#
+# This drafts the parts that are mechanical and easy to forget — every changelog entry in the
+# release, everyone whose PR is in it, the install note, the changelog link — and leaves the
+# writing to you. It does not invent copy: the entries come out verbatim, for you to tighten.
+# The body you publish should be shorter than what comes out of here.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION=""
+SINCE=""
+CHANGELOG="CHANGELOG.md"
+REPO=""
+
+CHECK=""
+
+usage() {
+    echo "Usage: $0 <version> [--since <ref>] [--changelog <file>] [--repo <owner/repo>]" >&2
+    echo "       $0 --check <file>" >&2
+    exit 64
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --since)     [ $# -ge 2 ] || usage; SINCE="$2"; shift 2 ;;
+        --changelog) [ $# -ge 2 ] || usage; CHANGELOG="$2"; shift 2 ;;
+        --repo)      [ $# -ge 2 ] || usage; REPO="$2"; shift 2 ;;
+        --check)     [ $# -ge 2 ] || usage; CHECK="$2"; shift 2 ;;
+        -*)          usage ;;
+        *)           [ -z "${VERSION}" ] || usage; VERSION="$1"; shift ;;
+    esac
+done
+
+fail() { echo "✗ $*" >&2; exit 1; }
+note() { echo "  $*" >&2; }
+
+# --- --check: is this draft finished? --------------------------------------------------------
+# The one mistake this whole script makes possible: publishing the draft as written. The
+# placeholder would become the release's first paragraph, which is exactly what the app shows
+# as the summary. Cheap to check, so check rather than remember.
+if [ -n "${CHECK}" ]; then
+    [ -f "${CHECK}" ] || fail "no such file: ${CHECK}"
+    if grep -q '^TODO:' "${CHECK}"; then
+        fail "${CHECK} still has the TODO placeholder — that would be the release's first paragraph"
+    fi
+    # `/^#/`, not an interval expression: not every awk supports `{1,6}`, and in markdown
+    # nothing but a heading starts a line with a hash anyway.
+    SUMMARY="$(awk '/^#/{exit} {print}' "${CHECK}" | tr -d '[:space:]')"
+    [ -n "${SUMMARY}" ] \
+        || fail "${CHECK} has nothing above its first heading — the app would show no summary"
+    echo "✓ ${CHECK} looks publishable" >&2
+    exit 0
+fi
+
+[ -n "${VERSION}" ] || usage
+
+[ -f "${CHANGELOG}" ] || fail "no ${CHANGELOG}"
+
+# --- Who owns the repo ---------------------------------------------------------------------
+# Needed only to tell the maintainer's own merges from everyone else's. Read from the remote
+# rather than hardcoded, so a fork or a rename doesn't silently credit the wrong person.
+if [ -z "${REPO}" ]; then
+    ORIGIN="$(git remote get-url origin 2>/dev/null || true)"
+    REPO="$(echo "${ORIGIN}" | sed -E 's#^(git@[^:]+:|https?://[^/]+/)##; s#\.git$##')"
+fi
+OWNER="${REPO%%/*}"
+[ -n "${OWNER}" ] || fail "couldn't work out the repo owner — pass --repo owner/repo"
+
+# --- The changelog section for this version -------------------------------------------------
+SECTION="$(awk -v want="## [${VERSION}]" '
+    index($0, want) == 1 { f = 1; next }
+    f && /^## \[/        { exit }
+    f                    { print }
+' "${CHANGELOG}")"
+
+# Entries, not just lines: a section holding only blank lines is as empty as no section.
+echo "${SECTION}" | grep -q '^- ' \
+    || fail "${CHANGELOG} has no entries under '## [${VERSION}]' — run this after release.sh has closed off the changelog"
+
+# --- Who contributed ------------------------------------------------------------------------
+# GitHub writes the PR number and the author's handle into every merge commit subject, and the
+# PR title into its body, so this needs no network and no API token.
+[ -n "${SINCE}" ] || SINCE="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)"
+RANGE="HEAD"
+[ -n "${SINCE}" ] && RANGE="${SINCE}..HEAD"
+
+THANKS=""
+CREDITED=""
+for sha in $(git log "${RANGE}" --merges --reverse --format='%H' 2>/dev/null || true); do
+    subject="$(git log -1 --format='%s' "${sha}")"
+    case "${subject}" in
+        "Merge pull request #"*)
+            pr="$(echo "${subject}" | sed -E 's/^Merge pull request #([0-9]+) from .*$/\1/')"
+            # `|` as the delimiter, not `#`: the pattern itself contains the `#` of `#[0-9]+`.
+            handle="$(echo "${subject}" | sed -E 's|^Merge pull request #[0-9]+ from ([^/]+)/.*$|\1|')"
+            title="$(git log -1 --format='%b' "${sha}" | head -1)"
+            # Case-insensitive: GitHub handles are, and "SorcRR" vs "sorcrr" would credit the
+            # maintainer in their own release notes.
+            [ "$(echo "${handle}" | tr 'A-Z' 'a-z')" = "$(echo "${OWNER}" | tr 'A-Z' 'a-z')" ] && continue
+            # A merge made by hand can carry no body, and "@caseyc —  (#5)" reads as a typo.
+            if [ -n "${title}" ]; then
+                THANKS="${THANKS}- **@${handle}** — ${title} (#${pr})
+"
+            else
+                THANKS="${THANKS}- **@${handle}** (#${pr})
+"
+            fi
+            CREDITED="${CREDITED} ${handle}"
+            ;;
+    esac
+done
+
+# A squash-merged PR leaves no merge commit to read, so its author would go uncredited with
+# nothing said about it. Say it — on stderr, so it reaches the person running this and not the
+# file they are about to publish.
+UNCREDITED="$(git log "${RANGE}" --no-merges --format='%an' 2>/dev/null | sort -u | while read -r name; do
+    [ -n "${name}" ] || continue
+    lower="$(echo "${name}" | tr 'A-Z' 'a-z' | tr -d ' ')"
+    known=" $(echo "${CREDITED} ${OWNER}" | tr 'A-Z' 'a-z' | tr -s ' ' '\n' | tr -d ' \t' | tr '\n' ' ')"
+    echo "${known}" | grep -qF " ${lower} " || echo "${name}"
+done)"
+
+# --- The draft -------------------------------------------------------------------------------
+
+cat <<EOF
+TODO: one line saying what this release is about — the app shows everything above the first
+heading as the summary. The entries below are verbatim from the changelog, which is written
+for contributors: tighten them for users, expect to cut most of it, and delete these lines.
+EOF
+
+# Verbatim. Tightening these is the editorial half, and a script that paraphrased them would
+# be inventing copy nobody reviewed.
+echo "${SECTION}" | awk 'NF { blank = 0; print; next } { if (!blank) print; blank = 1 }'
+
+# printf, not a heredoc: `${THANKS}` already ends in a newline, and a heredoc terminator is
+# matched against the source line, not against what the expansion produced.
+if [ -n "${THANKS}" ]; then
+    printf '\n### Thanks\n%s' "${THANKS}"
+fi
+
+cat <<EOF
+
+### Install
+This build is unsigned (no paid Apple Developer ID), so first launch shows the standard
+Gatekeeper warning. Right-click **MacRazer.app** in Finder → **Open** → **Open**. Only needed
+once. See the README for details.
+
+**Full changelog:** https://github.com/${REPO}/blob/master/${CHANGELOG}
+EOF
+
+# --- What the person running this needs to know ----------------------------------------------
+note ""
+note "Drafted from '## [${VERSION}]' in ${CHANGELOG}, over ${RANGE}."
+if [ -n "${THANKS}" ]; then
+    note "Credited:$(echo "${CREDITED}" | tr ' ' '\n' | grep -v '^$' | sed 's/^/ @/' | tr '\n' ' ')"
+else
+    note "No outside contributors in this range."
+fi
+if [ -n "${UNCREDITED}" ]; then
+    note ""
+    note "⚠ These authors wrote commits in the range but have no merge commit to credit them by"
+    note "  (a squash-merged PR leaves none). Add them to Thanks by hand:"
+    echo "${UNCREDITED}" | while read -r n; do note "    ${n}"; done
+fi
+note ""
+note "Edit before publishing. The TODO line at the top is not a release note."

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -71,10 +71,18 @@ fi
 # rather than hardcoded, so a fork or a rename doesn't silently credit the wrong person.
 if [ -z "${REPO}" ]; then
     ORIGIN="$(git remote get-url origin 2>/dev/null || true)"
-    REPO="$(echo "${ORIGIN}" | sed -E 's#^(git@[^:]+:|https?://[^/]+/)##; s#\.git$##')"
+    # Every spelling a clone can have, stripped one layer at a time: scheme, user@, host and
+    # its separator, then the .git suffix. Matching whole URL shapes instead missed `ssh://`,
+    # which left the owner as "ssh:" — so the maintainer was credited in their own notes and
+    # the changelog link pointed at github.com/ssh://git@github.com/…, both without a word.
+    REPO="$(echo "${ORIGIN}" \
+        | sed -E 's#^[A-Za-z][A-Za-z0-9+.-]*://##; s#^[^/]*@##; s#^[^:/]+[:/]+##; s#/+$##; s#\.git$##')"
 fi
+# Checked however it was arrived at, --repo included: everything downstream (who is excluded
+# from the credits, where the changelog link points) is only as good as this.
+echo "${REPO}" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' \
+    || fail "couldn't read owner/repo from '${ORIGIN:-${REPO}}' — pass --repo owner/repo"
 OWNER="${REPO%%/*}"
-[ -n "${OWNER}" ] || fail "couldn't work out the repo owner — pass --repo owner/repo"
 
 # --- The changelog section for this version -------------------------------------------------
 SECTION="$(awk -v want="## [${VERSION}]" '
@@ -94,19 +102,31 @@ echo "${SECTION}" | grep -q '^- ' \
 RANGE="HEAD"
 [ -n "${SINCE}" ] && RANGE="${SINCE}..HEAD"
 
+MERGES="$(git log "${RANGE}" --merges --reverse --format='%H' 2>/dev/null || true)"
+
 THANKS=""
 CREDITED=""
-for sha in $(git log "${RANGE}" --merges --reverse --format='%H' 2>/dev/null || true); do
+MALFORMED=""
+for sha in ${MERGES}; do
     subject="$(git log -1 --format='%s' "${sha}")"
     case "${subject}" in
         "Merge pull request #"*)
             pr="$(echo "${subject}" | sed -E 's/^Merge pull request #([0-9]+) from .*$/\1/')"
             # `|` as the delimiter, not `#`: the pattern itself contains the `#` of `#[0-9]+`.
             handle="$(echo "${subject}" | sed -E 's|^Merge pull request #[0-9]+ from ([^/]+)/.*$|\1|')"
-            title="$(git log -1 --format='%b' "${sha}" | head -1)"
+            # A sed that doesn't match prints its input unchanged, so a merge subject with the
+            # right prefix but the wrong shape — "Merge pull request #7 from somebody", no
+            # branch — put the whole subject line in the credits as if it were a handle.
+            # Say so rather than publishing it.
+            if ! echo "${pr}" | grep -Eq '^[0-9]+$' || ! echo "${handle}" | grep -Eq '^[A-Za-z0-9-]+$'; then
+                MALFORMED="${MALFORMED}${subject}
+"
+                continue
+            fi
             # Case-insensitive: GitHub handles are, and "SorcRR" vs "sorcrr" would credit the
             # maintainer in their own release notes.
             [ "$(echo "${handle}" | tr 'A-Z' 'a-z')" = "$(echo "${OWNER}" | tr 'A-Z' 'a-z')" ] && continue
+            title="$(git log -1 --format='%b' "${sha}" | head -1)"
             # A merge made by hand can carry no body, and "@caseyc —  (#5)" reads as a typo.
             if [ -n "${title}" ]; then
                 THANKS="${THANKS}- **@${handle}** — ${title} (#${pr})
@@ -123,12 +143,28 @@ done
 # A squash-merged PR leaves no merge commit to read, so its author would go uncredited with
 # nothing said about it. Say it — on stderr, so it reaches the person running this and not the
 # file they are about to publish.
-UNCREDITED="$(git log "${RANGE}" --no-merges --format='%an' 2>/dev/null | sort -u | while read -r name; do
-    [ -n "${name}" ] || continue
-    lower="$(echo "${name}" | tr 'A-Z' 'a-z' | tr -d ' ')"
-    known=" $(echo "${CREDITED} ${OWNER}" | tr 'A-Z' 'a-z' | tr -s ' ' '\n' | tr -d ' \t' | tr '\n' ' ')"
-    echo "${known}" | grep -qF " ${lower} " || echo "${name}"
-done)"
+#
+# Who is already accounted for is answered from the graph, not from spelling. Comparing a git
+# display name against a GitHub handle warned about "Casey Contributor" seconds after
+# crediting them as @caseyc, and warned the maintainer about their own commits whenever their
+# user.name wasn't their handle — which is most setups. A warning that fires every release is
+# one nobody reads, and the squash-merge it exists for goes past unseen.
+MERGED_IN=""
+for sha in ${MERGES}; do
+    # A merge's second parent side: the commits the PR brought with it.
+    MERGED_IN="${MERGED_IN}$(git log "${sha}^1..${sha}" --format='%ae' 2>/dev/null || true)
+"
+done
+# Whoever is cutting the release. Their own direct commits need no credit, and topology can't
+# tell those from a squash-merge — this can.
+ME_EMAIL="$(git config user.email 2>/dev/null || true)"
+
+UNCREDITED="$(git log "${RANGE}" --no-merges --format='%ae|%an' 2>/dev/null | sort -u | while IFS='|' read -r email name; do
+    [ -n "${email}" ] || continue
+    [ "${email}" = "${ME_EMAIL}" ] && continue
+    echo "${MERGED_IN}" | grep -qxF "${email}" && continue
+    echo "${name} <${email}>"
+done | sort -u)"
 
 # --- The draft -------------------------------------------------------------------------------
 
@@ -166,11 +202,26 @@ if [ -n "${THANKS}" ]; then
 else
     note "No outside contributors in this range."
 fi
+if [ -n "${MALFORMED}" ]; then
+    note ""
+    note "⚠ These merge commits look like PR merges but their subject doesn't parse, so"
+    note "  nobody was credited for them:"
+    # `|| continue`, not `&& note`: a loop whose body ends on a failing test returns that
+    # failure, and `set -e` then kills the script on the trailing blank line — which is
+    # exactly what this did, taking the uncredited warning below it down with it.
+    echo "${MALFORMED}" | while read -r m; do
+        [ -n "${m}" ] || continue
+        note "    ${m}"
+    done
+fi
 if [ -n "${UNCREDITED}" ]; then
     note ""
     note "⚠ These authors wrote commits in the range but have no merge commit to credit them by"
     note "  (a squash-merged PR leaves none). Add them to Thanks by hand:"
-    echo "${UNCREDITED}" | while read -r n; do note "    ${n}"; done
+    echo "${UNCREDITED}" | while read -r n; do
+        [ -n "${n}" ] || continue
+        note "    ${n}"
+    done
 fi
 note ""
 note "Edit before publishing. The TODO line at the top is not a release note."

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -48,10 +48,18 @@ step() { echo "▸ $*"; }
 # tree is dirty", which is true but describes the script's own mess. Say what to run instead.
 TEMP_FILES=""
 EDITS_APPLIED=0
+NOTES=""
+NOTES_CREATED=0
 on_exit() {
     local status=$?
     # shellcheck disable=SC2086
     [ -n "${TEMP_FILES}" ] && rm -f ${TEMP_FILES}
+    # A draft from a failed run is worth nothing and would block the retry, since the run that
+    # succeeds refuses to overwrite one. Only a draft that outlived a successful run can have
+    # been edited, and that is the one worth protecting.
+    if [ "${status}" -ne 0 ] && [ "${NOTES_CREATED}" -eq 1 ]; then
+        rm -f "${NOTES}"
+    fi
     if [ "${status}" -ne 0 ] && [ "${EDITS_APPLIED}" -eq 1 ]; then
         echo >&2
         echo "✗ Stopped part-way with the release edits already applied. To undo them:" >&2
@@ -178,7 +186,13 @@ step "Drafting the release notes…"
 # without one makes that page quietly not appear.
 mkdir -p dist
 NOTES="dist/RELEASE_NOTES-${VERSION}.md"
+# Never over a draft that already exists: this script is meant to be re-runnable, and a
+# re-run that silently truncated notes the maintainer had already written would destroy the
+# one artifact here that isn't regenerable. Same reasoning as refusing a dirty tree.
+[ -e "${NOTES}" ] \
+    && fail "${NOTES} already exists and may have been edited — move or delete it, then re-run"
 ./Scripts/release-notes.sh "${VERSION}" > "${NOTES}"
+NOTES_CREATED=1
 
 step "Building the DMGs…"
 ./Scripts/make-dmg.sh

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -171,6 +171,15 @@ sed -i '' "s/\"softwareVersion\": \"[^\"]*\"/\"softwareVersion\": \"${VERSION}\"
 grep -q "\"softwareVersion\": \"${VERSION}\"" "${SITE}" \
     || fail "couldn't update softwareVersion in ${SITE} — is it still there?"
 
+step "Drafting the release notes…"
+# Before the build, so a build failure doesn't lose them — and after the changelog is closed
+# off, since that's the section they're drafted from. The body is not cosmetic: the app
+# fetches it and builds the popover's "What's new" page out of it, so a release published
+# without one makes that page quietly not appear.
+mkdir -p dist
+NOTES="dist/RELEASE_NOTES-${VERSION}.md"
+./Scripts/release-notes.sh "${VERSION}" > "${NOTES}"
+
 step "Building the DMGs…"
 ./Scripts/make-dmg.sh
 
@@ -193,9 +202,14 @@ echo "    git diff"
 echo "    git commit -am 'Release v${VERSION}'"
 echo "    git push"
 echo "    git tag v${VERSION} && git push origin v${VERSION}"
+echo "    \$EDITOR ${NOTES}"
+echo "    ./Scripts/release-notes.sh --check ${NOTES}"
 echo "    gh release create v${VERSION} \\"
 echo "      dist/MacRazer.dmg dist/MacRazer-${VERSION}.dmg \\"
-echo "      --title 'v${VERSION}' --notes-from-tag"
+echo "      --title 'v${VERSION}' --notes-file ${NOTES}"
 echo
 echo "  Attach BOTH assets: the in-app updater fetches the fixed 'MacRazer.dmg' name, and the"
 echo "  versioned copy is what makes the Releases page self-describing."
+echo
+echo "  Edit ${NOTES} first — it is a draft of the mechanical parts (every entry, everyone"
+echo "  credited, the install note), not the finished copy. The app shows this text."

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -31,15 +31,16 @@ struct AboutView: View {
         }
         .padding(22)
         .frame(width: 460)
+        // Content that cannot be empty, rather than an `if let` inside the builder: the row
+        // that sets `showingNotes` is gated on the same notes, but the two gates sit far apart
+        // and a sheet with an empty body is a blank panel with no way out but Escape.
         .sheet(isPresented: $showingNotes) {
-            if let notes {
-                WhatsNewPage(version: AppInfo.displayVersion,
-                             notes: notes,
-                             canInstallInPlace: false,
-                             onBack: { showingNotes = false },
-                             onUpdate: nil) // already running it
-                    .frame(width: 380, height: 460)
-            }
+            WhatsNewPage(version: AppInfo.displayVersion,
+                         notes: notes ?? ReleaseNotes(summary: "", sections: []),
+                         canInstallInPlace: false,
+                         onBack: { showingNotes = false },
+                         onUpdate: nil) // already running it
+                .frame(width: 380, height: 460)
         }
     }
 

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -14,6 +14,13 @@ struct AboutView: View {
     /// and does nothing, with no compiler error.
     var onDone: () -> Void
 
+    /// Notes for the version this is the About box of, when the app has them. The popover's
+    /// "Updated to …" card is shown once and then dismissed; this is where they stay
+    /// findable afterwards, next to the version number they belong to.
+    var notes: ReleaseNotes?
+
+    @State private var showingNotes = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             header
@@ -24,6 +31,16 @@ struct AboutView: View {
         }
         .padding(22)
         .frame(width: 460)
+        .sheet(isPresented: $showingNotes) {
+            if let notes {
+                WhatsNewPage(version: AppInfo.displayVersion,
+                             notes: notes,
+                             canInstallInPlace: false,
+                             onBack: { showingNotes = false },
+                             onUpdate: nil) // already running it
+                    .frame(width: 380, height: 460)
+            }
+        }
     }
 
     // MARK: Header
@@ -48,6 +65,7 @@ struct AboutView: View {
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(Color.razerGreen)
                 }
+                whatsNewRow
             }
             Spacer(minLength: 0)
         }
@@ -90,6 +108,27 @@ struct AboutView: View {
             Link("View the source", destination: ProjectLinks.repo)
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(Color.razerGreen)
+        }
+    }
+
+    // MARK: What's new
+
+    /// Sits under the version because that is the question it answers. Shown only when the
+    /// app actually has the notes for the version running — a row that opened an empty page
+    /// would be worse than no row.
+    @ViewBuilder
+    private var whatsNewRow: some View {
+        if notes != nil {
+            Button { showingNotes = true } label: {
+                HStack(spacing: 4) {
+                    Text("What's new in \(AppInfo.displayVersion)")
+                    Image(systemName: "chevron.right").font(.system(size: 8, weight: .semibold))
+                }
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(Color.razerGreen)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
     }
 

--- a/Sources/MacRazer/AboutWindowController.swift
+++ b/Sources/MacRazer/AboutWindowController.swift
@@ -13,7 +13,8 @@ final class AboutWindowController: AppWindowPresenter {
 
     func show() {
         if window == nil {
-            let root = AboutView(onDone: { [weak self] in self?.window?.close() })
+            let root = AboutView(onDone: { [weak self] in self?.window?.close() },
+                                 notes: UpdateChecker.notesForRunningVersion())
             let hosting = NSHostingController(rootView: root)
             hosting.sizingOptions = [.preferredContentSize]
             let w = NSWindow(contentViewController: hosting)

--- a/Sources/MacRazer/AboutWindowController.swift
+++ b/Sources/MacRazer/AboutWindowController.swift
@@ -8,22 +8,33 @@ import SwiftUI
 @MainActor
 final class AboutWindowController: AppWindowPresenter {
     private var window: NSWindow?
+    /// Held so the root view can be rebuilt on each open. Without it the window is created
+    /// once and keeps whatever it was built with — and it is built with the release notes,
+    /// which arrive from a background check that may not have returned yet. Opening About in
+    /// the first seconds after launch would otherwise hide the "What's new" row for the rest
+    /// of the session.
+    private var hosting: NSHostingController<AboutView>?
 
     var isVisible: Bool { window?.isVisible ?? false }
 
     func show() {
-        if window == nil {
-            let root = AboutView(onDone: { [weak self] in self?.window?.close() },
-                                 notes: UpdateChecker.notesForRunningVersion())
-            let hosting = NSHostingController(rootView: root)
-            hosting.sizingOptions = [.preferredContentSize]
-            let w = NSWindow(contentViewController: hosting)
+        // Rebuilt on every open, not once: `notes` comes from a background check that may not
+        // have returned when the window was first created.
+        let root = AboutView(onDone: { [weak self] in self?.window?.close() },
+                             notes: UpdateChecker.notesForRunningVersion())
+        if let hosting {
+            hosting.rootView = root
+        } else {
+            let controller = NSHostingController(rootView: root)
+            controller.sizingOptions = [.preferredContentSize]
+            let w = NSWindow(contentViewController: controller)
             w.title = "About MacRazer"
             w.styleMask = [.titled, .closable]
             w.isReleasedWhenClosed = false
             // Match the popover and the other windows: the green accent needs a dark ground.
             w.appearance = NSAppearance(named: .darkAqua)
             w.center()
+            hosting = controller
             window = w
         }
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -179,6 +179,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
                 self?.autoInstallIfEnabled(available: version)
             }
             .store(in: &cancellables)
+        // Before the check, and synchronously: this compares the running version against the
+        // last one recorded and then records the new one, so it has to happen exactly once per
+        // launch and before anything else can write that key.
+        updateChecker.loadInstalledVersionState()
         Task { await updateChecker.checkForUpdatesIfDue() }
         let timer = Timer(timeInterval: 24 * 60 * 60, repeats: true) { [weak self] _ in
             Task { await self?.updateChecker.checkForUpdatesIfDue() }

--- a/Sources/MacRazer/AppInfo.swift
+++ b/Sources/MacRazer/AppInfo.swift
@@ -38,6 +38,9 @@ enum ProjectLinks {
     static let developer = URL(string: "https://github.com/SorcRR")!
 
     static let issues = repo.appendingPathComponent("issues")
+    /// Where "Full release notes" goes: the popover shows a parsed summary, this is the
+    /// unabridged original.
+    static let latestRelease = repo.appendingPathComponent("releases/latest")
     /// GitHub's fixed "latest" shortcut; `Scripts/make-dmg.sh` keeps the asset name constant
     /// precisely so this URL never has to change.
     static let latestDMG = repo.appendingPathComponent("releases/latest/download/MacRazer.dmg")

--- a/Sources/MacRazer/LaunchAtLogin.swift
+++ b/Sources/MacRazer/LaunchAtLogin.swift
@@ -31,7 +31,10 @@ final class LaunchAtLogin: ObservableObject {
     /// (or won't exist) at the next boot. See `AppLocation`.
     @Published private(set) var isSupported: Bool
 
-    private static let appliedDefaultKey = "launchAtLoginDefaultApplied"
+    /// Not private: `UpdateChecker` reads it as evidence that some version of the app has run
+    /// on this machine before. Sharing the constant rather than the string, because a defaults
+    /// key spelled out in two files is a rename away from being quietly wrong in one of them.
+    static let appliedDefaultKey = "launchAtLoginDefaultApplied"
 
     init() {
         isSupported = AppLocation.installedBundleURL != nil

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -150,6 +150,9 @@ struct PopoverView: View {
         VStack(alignment: .leading, spacing: 10) {
             headerCard
             if let version = updateChecker.latestVersion { updateCard(version) }
+            // Never both: an update waiting to be installed is the more useful thing to say
+            // than one that already was.
+            else if let installed = updateChecker.justUpdatedTo { updatedCard(installed) }
             // A Razer mouse on Bluetooth can't be controlled (no control protocol over BT) —
             // explain it instead of just showing "offline".
             if controller.bluetoothMouseName != nil && !controller.connected { bluetoothNotice }
@@ -514,14 +517,67 @@ struct PopoverView: View {
     /// call site can at worst produce a thin page with a working back button, never a blank
     /// dead end.
     private var whatsNewPage: some View {
-        WhatsNewPage(version: updateChecker.latestVersion ?? appVersion,
-                     notes: updateChecker.latestNotes ?? ReleaseNotes(summary: "", sections: []),
-                     canInstallInPlace: updateChecker.canInstallInPlace,
-                     onBack: { page = .main },
-                     onUpdate: {
-                         page = .main
-                         Task { await updateChecker.downloadAndInstall() }
-                     })
+        // Reached from either card, and they are about different releases: one waiting, one
+        // already running. An update on offer wins, matching which card is showing.
+        let pending = updateChecker.latestVersion
+        return WhatsNewPage(version: pending ?? appVersion,
+                            notes: (pending != nil ? updateChecker.latestNotes : updateChecker.installedNotes)
+                                ?? ReleaseNotes(summary: "", sections: []),
+                            canInstallInPlace: updateChecker.canInstallInPlace,
+                            // Nothing to install when the notes are about what's already
+                            // running, so the page shows no button at all rather than one that
+                            // would re-download the version you are reading about.
+                            onBack: { page = .main },
+                            onUpdate: pending == nil ? nil : {
+                                page = .main
+                                Task { await updateChecker.downloadAndInstall() }
+                            })
+    }
+
+    /// Shown once, on the first launch after the version changes.
+    ///
+    /// With automatic installs on there is no update card and never was one — this is the
+    /// only place the app says a release happened. It is a row and a dismiss, because it is
+    /// news rather than a decision.
+    /// Takes the version only to keep the card and the announcement in step; it shows
+    /// `appVersion`, since `justUpdatedTo` carries the *comparable* version — which is "0" for
+    /// an unversioned dev build, and "Updated to 0" is not a sentence.
+    private func updatedCard(_ version: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.razerGreen)
+                    .font(.system(size: 14, weight: .semibold))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Updated to \(appVersion)").font(.system(size: 12, weight: .semibold))
+                    Text("You're on the latest version.")
+                        .font(.system(size: 11)).foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Button {
+                    updateChecker.dismissAnnouncement()
+                } label: {
+                    Image(systemName: "xmark").font(.system(size: 9, weight: .bold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tertiary)
+            }
+            if updateChecker.installedNotes != nil {
+                Button { page = .whatsNew } label: {
+                    HStack(spacing: 6) {
+                        Text("What's new in \(appVersion)").font(.system(size: 11, weight: .medium))
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
+                    }
+                    .foregroundStyle(Color.razerGreen)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.razerGreen.opacity(0.12), in: RoundedRectangle(cornerRadius: 13))
     }
 
     private func updateProgress(_ fraction: Double) -> some View {

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -32,7 +32,7 @@ struct PopoverView: View {
     /// The preview passes an explicit `{}`.
     var onOpenSettings: () -> Void
 
-    enum Page { case main, color, buttons, usage, profiles }
+    enum Page { case main, color, buttons, usage, profiles, whatsNew }
     @State private var page: Page = .main
     @State private var isAddingProfile = false
     @State private var newProfileName = ""
@@ -78,6 +78,7 @@ struct PopoverView: View {
             case .buttons: buttonsPage.transition(.move(edge: .trailing))
             case .usage: usagePage.transition(.move(edge: .trailing))
             case .profiles: profilesPage.transition(.move(edge: .trailing))
+            case .whatsNew: whatsNewPage.transition(.move(edge: .trailing))
             }
         }
         .frame(width: popoverWidth)
@@ -448,6 +449,21 @@ struct PopoverView: View {
             if let error = updateChecker.downloadError {
                 Text(error).font(.system(size: 10.5)).foregroundStyle(Color.batteryLow)
             }
+            // A row, not the notes. The main page is already at the height a menu bar
+            // popover can use; the notes get their own page rather than competing with the
+            // seven cards above them.
+            if updateChecker.phase == .idle, updateChecker.latestNotes != nil {
+                Button { page = .whatsNew } label: {
+                    HStack(spacing: 6) {
+                        Text("What's new in \(version)").font(.system(size: 11, weight: .medium))
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
+                    }
+                    .foregroundStyle(Color.razerGreen)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
             switch updateChecker.phase {
             case .idle: updateActionButton
             case .downloading(let fraction): updateProgress(fraction)
@@ -489,6 +505,23 @@ struct PopoverView: View {
         .buttonStyle(.borderedProminent)
         .tint(.razerGreen)
         .controlSize(.small)
+    }
+
+    /// The release notes, given the whole popover. Reached from the update card's one row.
+    ///
+    /// The empty fallback is unreachable today — the row that navigates here is gated on the
+    /// same `latestNotes` — but it still renders the page rather than nothing, so a future
+    /// call site can at worst produce a thin page with a working back button, never a blank
+    /// dead end.
+    private var whatsNewPage: some View {
+        WhatsNewPage(version: updateChecker.latestVersion ?? appVersion,
+                     notes: updateChecker.latestNotes ?? ReleaseNotes(summary: "", sections: []),
+                     canInstallInPlace: updateChecker.canInstallInPlace,
+                     onBack: { page = .main },
+                     onUpdate: {
+                         page = .main
+                         Task { await updateChecker.downloadAndInstall() }
+                     })
     }
 
     private func updateProgress(_ fraction: Double) -> some View {

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -152,7 +152,7 @@ struct PopoverView: View {
             if let version = updateChecker.latestVersion { updateCard(version) }
             // Never both: an update waiting to be installed is the more useful thing to say
             // than one that already was.
-            else if let installed = updateChecker.justUpdatedTo { updatedCard(installed) }
+            else if updateChecker.justUpdatedTo != nil { updatedCard }
             // A Razer mouse on Bluetooth can't be controlled (no control protocol over BT) —
             // explain it instead of just showing "offline".
             if controller.bluetoothMouseName != nil && !controller.connected { bluetoothNotice }
@@ -534,15 +534,16 @@ struct PopoverView: View {
                             })
     }
 
-    /// Shown once, on the first launch after the version changes.
+    /// Shown after the version changes, until dismissed.
     ///
-    /// With automatic installs on there is no update card and never was one — this is the
-    /// only place the app says a release happened. It is a row and a dismiss, because it is
-    /// news rather than a decision.
-    /// Takes the version only to keep the card and the announcement in step; it shows
-    /// `appVersion`, since `justUpdatedTo` carries the *comparable* version — which is "0" for
-    /// an unversioned dev build, and "Updated to 0" is not a sentence.
-    private func updatedCard(_ version: String) -> some View {
+    /// With automatic installs on there is no update card and never was one — this is the only
+    /// place the app says a release happened. It is a row and a dismiss, because it is news
+    /// rather than a decision.
+    ///
+    /// Takes no version: `justUpdatedTo` carries the *comparable* version, which is "0" for an
+    /// unversioned dev build, and "Updated to 0" is not a sentence. It always describes the
+    /// running build, so `appVersion` is both correct and the one worth showing.
+    private var updatedCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "checkmark.circle.fill")

--- a/Sources/MacRazer/PreviewNotes.swift
+++ b/Sources/MacRazer/PreviewNotes.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+/// Sample copy for the `render-*` commands.
+///
+/// The real v0.3.0 release body, so the previews show the notes page at the length releases
+/// actually reach rather than at the length of a tidy sample. A `static let` rather than a
+/// top-level `let` in `main.swift`: statics are lazy, so the menu bar app never touches it,
+/// and `render-about` can reach it too.
+enum PreviewNotes {
+    static let releaseBody = """
+MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
+
+### Added
+- **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
+- **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it, checks it, replaces itself and relaunches. No more dragging a DMG.
+- **"Install updates automatically"**, off by default. It never starts while the popover or a window is open, since installing ends in a relaunch.
+- **A Settings window**, reached from the right-click menu or the gear in the footer.
+- **An About window**, with the licence and proper credit to OpenRazer.
+- The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
+
+### Fixed
+- Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
+
+### Install
+This build is unsigned, so first launch shows the standard Gatekeeper warning.
+
+**Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
+"""
+}

--- a/Sources/MacRazer/ReleaseNotes.swift
+++ b/Sources/MacRazer/ReleaseNotes.swift
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// Turns a GitHub release body into something the popover can show in 320 points.
+///
+/// Pure — no network, no UI — so every shape the notes come in can be replayed in a test,
+/// which matters because the input is prose written by hand months apart. The parser is
+/// deliberately forgiving: anything it can't classify still reaches the reader as plain text
+/// rather than being dropped.
+struct ReleaseNotes: Equatable {
+    /// One bullet, split so the popover can set the first line apart from the rest.
+    struct Item: Equatable {
+        /// The gist. Empty when the bullet has no natural lead, in which case `detail` carries
+        /// the whole thing rather than the item being silently thinned to nothing.
+        let headline: String
+        let detail: String
+    }
+
+    /// A heading, e.g. "Added" / "Fixed", with the bullets under it. The title is empty for
+    /// bullets that appear before any heading.
+    struct Section: Equatable {
+        let title: String
+        let items: [Item]
+    }
+
+    /// The prose above the first heading — usually one line saying what the release is about.
+    let summary: String
+    let sections: [Section]
+
+    var isEmpty: Bool { summary.isEmpty && sections.isEmpty }
+
+    /// Sections that exist for someone reading the release page, not someone already running
+    /// the app. Install instructions are the obvious one: by the time these notes are on
+    /// screen the reader has plainly managed it.
+    private static let droppedSections: Set<String> = ["install", "installation", "download"]
+
+    /// A headline longer than this stops being a headline and is just the sentence again in
+    /// bold, so the item is left as one block of detail instead.
+    private static let maxHeadline = 90
+
+    static func parse(_ body: String) -> ReleaseNotes {
+        var summaryLines: [String] = []
+        var sections: [Section] = []
+        var currentTitle: String?
+        var currentBullets: [String] = []
+
+        func closeSection() {
+            defer { currentTitle = nil; currentBullets = [] }
+            guard !currentBullets.isEmpty else { return }
+            // An untitled section is a body that opens straight into a list, with no headings
+            // at all. It still gets shown — the view leaves the title label off.
+            let title = currentTitle ?? ""
+            guard !droppedSections.contains(title.lowercased()) else { return }
+            sections.append(Section(title: title, items: currentBullets.map(item(from:))))
+        }
+
+        var previousLineWasBlank = true
+        for rawLine in body.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            // The changelog link is a footer for the release page; in the app it's a dead end.
+            if line.lowercased().hasPrefix("**full changelog:") { break }
+            defer { previousLineWasBlank = line.isEmpty }
+
+            if let heading = headingTitle(line) {
+                closeSection()
+                currentTitle = heading
+            } else if let bullet = bulletText(line) {
+                currentBullets.append(bullet)
+            } else if currentTitle == nil, !line.isEmpty {
+                // Blockquote callouts read as emphasis on the page and as clutter here; keep
+                // the words, drop the marker.
+                summaryLines.append(strip(line.hasPrefix("> ") ? String(line.dropFirst(2)) : line))
+            } else if !line.isEmpty, !previousLineWasBlank, !currentBullets.isEmpty {
+                // A wrapped bullet. Markdown joins a line that follows one directly, and a
+                // long bullet split over two lines is the one way a hand-written body loses
+                // half a sentence here.
+                currentBullets[currentBullets.count - 1] += " " + line
+            }
+            // Anything left is prose under a heading with no bullets — a section like Install
+            // written as paragraphs. `closeSection` drops it for being empty.
+        }
+        closeSection()
+
+        return ReleaseNotes(summary: summaryLines.joined(separator: "\n\n"), sections: sections)
+    }
+
+    /// The title of an ATX heading at any level, or nil.
+    ///
+    /// Any level, because our own notes use `###` while GitHub's "Generate release notes"
+    /// button emits `##` — and a body whose headings all went unrecognised would arrive as
+    /// one undifferentiated blob of summary.
+    private static func headingTitle(_ line: String) -> String? {
+        let hashes = line.prefix { $0 == "#" }
+        guard !hashes.isEmpty, line.dropFirst(hashes.count).hasPrefix(" ") else { return nil }
+        let title = line.dropFirst(hashes.count).trimmingCharacters(in: .whitespaces)
+        return title.isEmpty ? nil : strip(title)
+    }
+
+    /// The text of a list item, or nil. `*` and `+` are markdown list markers too, and the
+    /// generated notes use `*`.
+    private static func bulletText(_ line: String) -> String? {
+        for marker in ["- ", "* ", "+ "] where line.hasPrefix(marker) {
+            return String(line.dropFirst(marker.count))
+        }
+        return nil
+    }
+
+    /// Splits a bullet into a lead and the rest.
+    ///
+    /// Real notes come in at least four shapes: bold lead then detail, a bold run in the
+    /// middle, a quoted feature name in bold, and no emphasis at all. A leading bold run is
+    /// the clearest signal of intent, so it wins; otherwise the first sentence stands in, and
+    /// if even that is too long the item is left whole.
+    static func item(from bullet: String) -> Item {
+        let text = bullet.trimmingCharacters(in: .whitespaces)
+
+        if text.hasPrefix("**"), let close = text.range(of: "**", range: text.index(text.startIndex, offsetBy: 2)..<text.endIndex) {
+            let headline = String(text[text.index(text.startIndex, offsetBy: 2)..<close.lowerBound])
+            let rest = String(text[close.upperBound...])
+            if headline.count <= maxHeadline {
+                return Item(headline: strip(headline), detail: strip(trimLead(rest)))
+            }
+        }
+
+        if let end = firstSentenceEnd(text) {
+            let headline = String(text[..<end])
+            if headline.count <= maxHeadline {
+                let rest = String(text[end...])
+                return Item(headline: strip(headline), detail: strip(trimLead(rest)))
+            }
+        }
+        return Item(headline: "", detail: strip(text))
+    }
+
+    /// Index just past the first ". " — not `.` alone, which would cut "0.3.1" and "e.g." in
+    /// half, and not "…", which these notes use for menu titles like "Settings…".
+    private static func firstSentenceEnd(_ text: String) -> String.Index? {
+        guard let r = text.range(of: ". ") else {
+            return text.hasSuffix(".") ? text.endIndex : nil
+        }
+        return r.upperBound
+    }
+
+    /// Drops the punctuation and whitespace left dangling when a lead is split off.
+    private static func trimLead(_ s: String) -> String {
+        var out = s
+        while let f = out.first, f == "," || f == ":" || f == "." || f == " " { out.removeFirst() }
+        return out
+    }
+
+    /// Markdown emphasis, code ticks and links reduced to their text. SwiftUI can render
+    /// markdown, but only cleanly for a whole string — these fragments are recombined into
+    /// styled runs by the view, so they arrive as plain text.
+    static func strip(_ s: String) -> String {
+        var out = s.replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "`", with: "")
+        // [text](url) → text
+        while let open = out.range(of: "["), let close = out.range(of: "](", range: open.upperBound..<out.endIndex),
+              let end = out.range(of: ")", range: close.upperBound..<out.endIndex) {
+            out.replaceSubrange(open.lowerBound..<end.upperBound, with: out[open.upperBound..<close.lowerBound])
+        }
+        return out.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Sources/MacRazer/ReleaseNotes.swift
+++ b/Sources/MacRazer/ReleaseNotes.swift
@@ -57,6 +57,9 @@ struct ReleaseNotes: Equatable {
         }
 
         var previousLineWasBlank = true
+        // The summary ends at the first bullet or heading and does not resume: prose further
+        // down belongs where it was written, not hoisted above the sections it followed.
+        var inSummary = true
         for rawLine in body.components(separatedBy: .newlines) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             // The changelog link is a footer for the release page; in the app it's a dead end.
@@ -64,14 +67,24 @@ struct ReleaseNotes: Equatable {
             defer { previousLineWasBlank = line.isEmpty }
 
             if let heading = headingTitle(line) {
+                inSummary = false
                 closeSection()
                 currentTitle = heading
             } else if let bullet = bulletText(line) {
+                inSummary = false
                 currentBullets.append(bullet)
-            } else if currentTitle == nil, !line.isEmpty {
+            } else if inSummary, !line.isEmpty {
                 // Blockquote callouts read as emphasis on the page and as clutter here; keep
                 // the words, drop the marker.
-                summaryLines.append(strip(line.hasPrefix("> ") ? String(line.dropFirst(2)) : line))
+                let text = strip(line.hasPrefix("> ") ? String(line.dropFirst(2)) : line)
+                // Markdown wraps: a paragraph split over several source lines is one
+                // paragraph, and joining them with a break instead put a blank line through
+                // the middle of the summary sentence. Only a blank line starts a new one.
+                if previousLineWasBlank || summaryLines.isEmpty {
+                    summaryLines.append(text)
+                } else {
+                    summaryLines[summaryLines.count - 1] += " " + text
+                }
             } else if !line.isEmpty, !previousLineWasBlank, !currentBullets.isEmpty {
                 // A wrapped bullet. Markdown joins a line that follows one directly, and a
                 // long bullet split over two lines is the one way a hand-written body loses
@@ -159,10 +172,22 @@ struct ReleaseNotes: Equatable {
     static func strip(_ s: String) -> String {
         var out = s.replacingOccurrences(of: "**", with: "")
             .replacingOccurrences(of: "`", with: "")
-        // [text](url) → text
-        while let open = out.range(of: "["), let close = out.range(of: "](", range: open.upperBound..<out.endIndex),
-              let end = out.range(of: ")", range: close.upperBound..<out.endIndex) {
-            out.replaceSubrange(open.lowerBound..<end.upperBound, with: out[open.upperBound..<close.lowerBound])
+        // [text](url) → text. The opening bracket has to be the one that actually starts the
+        // link: pairing the *first* `[` with the first later `](` let a stray bracket swallow
+        // everything between it and the next real link.
+        var searchFrom = out.startIndex
+        while let open = out.range(of: "[", range: searchFrom..<out.endIndex) {
+            guard let close = out.range(of: "](", range: open.upperBound..<out.endIndex),
+                  let end = out.range(of: ")", range: close.upperBound..<out.endIndex) else { break }
+            // Another `[` between this one and the `]` means this one isn't the link's opener.
+            if out.range(of: "[", range: open.upperBound..<close.lowerBound) != nil {
+                searchFrom = open.upperBound
+                continue
+            }
+            let text = String(out[open.upperBound..<close.lowerBound])
+            out.replaceSubrange(open.lowerBound..<end.upperBound, with: text)
+            // Resume after the text just substituted, so a `[` inside it is not re-examined.
+            searchFrom = out.index(open.lowerBound, offsetBy: text.count)
         }
         return out.trimmingCharacters(in: .whitespaces)
     }

--- a/Sources/MacRazer/ReleaseNotes.swift
+++ b/Sources/MacRazer/ReleaseNotes.swift
@@ -143,10 +143,13 @@ struct ReleaseNotes: Equatable {
         return r.upperBound
     }
 
-    /// Drops the punctuation and whitespace left dangling when a lead is split off.
+    /// Drops the punctuation and whitespace left dangling when a lead is split off. Dashes
+    /// included: `**Name** — what it does` is the shape our own notes use most, and leaving
+    /// the dash puts "— what it does" on its own line looking like a mistake.
+    private static let leadJunk: Set<Character> = [",", ":", ".", " ", "—", "–", "-"]
     private static func trimLead(_ s: String) -> String {
         var out = s
-        while let f = out.first, f == "," || f == ":" || f == "." || f == " " { out.removeFirst() }
+        while let f = out.first, leadJunk.contains(f) { out.removeFirst() }
         return out
     }
 

--- a/Sources/MacRazer/UpdateAnnouncement.swift
+++ b/Sources/MacRazer/UpdateAnnouncement.swift
@@ -36,4 +36,28 @@ enum UpdateAnnouncement {
         // only evidence that the app has run here before tells them apart.
         return hasRunBefore
     }
+
+    /// The version whose announcement is outstanding after this launch, or nil.
+    ///
+    /// An announcement has to outlive the launch that noticed it. The card is set on the
+    /// launch *after* an install, and a menu bar app that starts at login can go days without
+    /// its popover being opened — so deriving it once and keeping it in memory means a reboot,
+    /// a quit, or a crash in between loses it for good, on exactly the automatic-install path
+    /// it exists to serve.
+    ///
+    /// - Parameter storedPending: an announcement carried over from an earlier launch.
+    static func pending(lastRun: String?,
+                        current: String,
+                        dismissed: String?,
+                        storedPending: String?,
+                        hasRunBefore: Bool) -> String? {
+        if shouldAnnounce(lastRun: lastRun, current: current,
+                          dismissed: dismissed, hasRunBefore: hasRunBefore) {
+            return current
+        }
+        // Still owed, and still about what is running. A pending announcement for some other
+        // version is stale — you rolled back, or updated again before reading it — and the
+        // version you are on now is the only one worth talking about.
+        return storedPending == current ? current : nil
+    }
 }

--- a/Sources/MacRazer/UpdateAnnouncement.swift
+++ b/Sources/MacRazer/UpdateAnnouncement.swift
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import Foundation
+
+/// Whether this launch is the first one on a new version, and so worth saying something about.
+///
+/// The app cannot otherwise tell: it installs updates itself and relaunches, and with
+/// "Install updates automatically" on it does that without ever showing the update card. That
+/// is what the setting is for, but it means someone can go from 0.3.0 to 0.3.2 having never
+/// seen a word about what changed. Comparing the running version against the last one that
+/// ran is the only signal there is.
+///
+/// Pure, because the cases that matter are the ones that are awkward to reach by hand: a first
+/// install must not claim to be an update, and a downgrade is still a change worth announcing.
+enum UpdateAnnouncement {
+    /// - Parameters:
+    ///   - lastRun: the version recorded at the previous launch, or nil on a first run.
+    ///   - current: the version running now.
+    ///   - dismissed: the version whose announcement was already waved away.
+    static func shouldAnnounce(lastRun: String?, current: String, dismissed: String?) -> Bool {
+        // A first install is not an update. There is no "what's new" for someone who has never
+        // seen the old one, and "Updated to 0.3.1" on first launch is simply false.
+        guard let lastRun, !lastRun.isEmpty else { return false }
+        guard lastRun != current else { return false }
+        // Dismissing is per-version, so the next release announces itself again.
+        return dismissed != current
+    }
+}

--- a/Sources/MacRazer/UpdateAnnouncement.swift
+++ b/Sources/MacRazer/UpdateAnnouncement.swift
@@ -18,12 +18,22 @@ enum UpdateAnnouncement {
     ///   - lastRun: the version recorded at the previous launch, or nil on a first run.
     ///   - current: the version running now.
     ///   - dismissed: the version whose announcement was already waved away.
-    static func shouldAnnounce(lastRun: String?, current: String, dismissed: String?) -> Bool {
-        // A first install is not an update. There is no "what's new" for someone who has never
-        // seen the old one, and "Updated to 0.3.1" on first launch is simply false.
-        guard let lastRun, !lastRun.isEmpty else { return false }
-        guard lastRun != current else { return false }
+    ///   - hasRunBefore: whether an older version of the app left any trace on this machine.
+    ///     Consulted only when no version was recorded, which is true in two very different
+    ///     situations: a genuinely new install, and an upgrade *from* a version that predates
+    ///     this bookkeeping. Without it the release that introduces the feature is the one
+    ///     release it stays silent for.
+    static func shouldAnnounce(lastRun: String?,
+                               current: String,
+                               dismissed: String?,
+                               hasRunBefore: Bool) -> Bool {
         // Dismissing is per-version, so the next release announces itself again.
-        return dismissed != current
+        guard dismissed != current else { return false }
+        if let lastRun, !lastRun.isEmpty { return lastRun != current }
+        // A first install is not an update: there is no "what's new" for someone who has never
+        // seen the old one, and "Updated to 0.3.1" on a first launch is simply false. But an
+        // upgrade from a build that never recorded a version looks identical from here, and
+        // only evidence that the app has run here before tells them apart.
+        return hasRunBefore
     }
 }

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -88,6 +88,7 @@ final class UpdateChecker: ObservableObject {
     private static let lastFoundNotesKey = "lastFoundUpdateNotes"
     private static let lastRunVersionKey = "lastRunVersion"
     private static let dismissedAnnouncementKey = "dismissedUpdateAnnouncement"
+    private static let pendingAnnouncementKey = "pendingUpdateAnnouncement"
 
     private struct GitHubRelease: Decodable {
         let tag_name: String
@@ -195,12 +196,19 @@ final class UpdateChecker: ObservableObject {
     func loadInstalledVersionState() {
         let defaults = UserDefaults.standard
         let current = currentVersion
-        let lastRun = defaults.string(forKey: Self.lastRunVersionKey)
-        if UpdateAnnouncement.shouldAnnounce(lastRun: lastRun,
-                                             current: current,
-                                             dismissed: defaults.string(forKey: Self.dismissedAnnouncementKey),
-                                             hasRunBefore: Self.hasRunBefore(defaults)) {
-            justUpdatedTo = current
+        let pending = UpdateAnnouncement.pending(
+            lastRun: defaults.string(forKey: Self.lastRunVersionKey),
+            current: current,
+            dismissed: defaults.string(forKey: Self.dismissedAnnouncementKey),
+            storedPending: defaults.string(forKey: Self.pendingAnnouncementKey),
+            hasRunBefore: Self.hasRunBefore(defaults))
+        justUpdatedTo = pending
+        // Written down rather than only held: the card waits for the popover to be opened,
+        // which can be days, and a reboot in between must not swallow it.
+        if let pending {
+            defaults.set(pending, forKey: Self.pendingAnnouncementKey)
+        } else {
+            defaults.removeObject(forKey: Self.pendingAnnouncementKey)
         }
         defaults.set(current, forKey: Self.lastRunVersionKey)
         installedNotes = Self.installedNotes(current: current)
@@ -221,10 +229,18 @@ final class UpdateChecker: ObservableObject {
     }
 
     func dismissAnnouncement() {
+        let defaults = UserDefaults.standard
         if let version = justUpdatedTo {
-            UserDefaults.standard.set(version, forKey: Self.dismissedAnnouncementKey)
+            defaults.set(version, forKey: Self.dismissedAnnouncementKey)
         }
+        defaults.removeObject(forKey: Self.pendingAnnouncementKey)
         justUpdatedTo = nil
+    }
+
+    /// The same notes, for a caller with no `UpdateChecker` to hand — the About window, which
+    /// observes nothing.
+    static func notesForRunningVersion() -> ReleaseNotes? {
+        installedNotes(current: AppInfo.comparableVersion)
     }
 
     /// The cached notes, but only when they are demonstrably about the version running.
@@ -233,12 +249,6 @@ final class UpdateChecker: ObservableObject {
     /// or not it was newer — so this answers for someone who installed the DMG by hand too,
     /// from the first check after they did. A mismatch means the cache is about some other
     /// release and showing it would be worse than showing nothing.
-    /// The same notes, for a caller with no `UpdateChecker` to hand — the About window, which
-    /// observes nothing and is built fresh each time it opens.
-    static func notesForRunningVersion() -> ReleaseNotes? {
-        installedNotes(current: AppInfo.comparableVersion)
-    }
-
     private static func installedNotes(current: String) -> ReleaseNotes? {
         let defaults = UserDefaults.standard
         return notes(for: current,

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -41,6 +41,18 @@ final class UpdateChecker: ObservableObject {
     /// empty page.
     @Published private(set) var latestNotes: ReleaseNotes?
 
+    /// Notes for the version that is *running*, so they survive the thing they describe.
+    ///
+    /// The check that found the release cached its body; after the install and relaunch, that
+    /// release is what is running, so the same cache answers "what changed?" afterwards. Kept
+    /// separate from `latestNotes` because the two can both exist — you can be reading about
+    /// the release you just installed when the next one appears.
+    @Published private(set) var installedNotes: ReleaseNotes?
+
+    /// Set on the first launch after the version changes, until dismissed. The one way someone
+    /// with automatic installs on finds out a release happened at all.
+    @Published private(set) var justUpdatedTo: String?
+
     /// The error from the last failed install, kept raw (not just its message) so
     /// `AutoInstallPolicy` can tell a dropped connection from a payload that will never work.
     private(set) var lastInstallError: Error?
@@ -74,6 +86,8 @@ final class UpdateChecker: ObservableObject {
     private static let lastFoundKey = "lastFoundUpdateVersion"
     private static let autoInstallKey = "autoInstallUpdates"
     private static let lastFoundNotesKey = "lastFoundUpdateNotes"
+    private static let lastRunVersionKey = "lastRunVersion"
+    private static let dismissedAnnouncementKey = "dismissedUpdateAnnouncement"
 
     private struct GitHubRelease: Decodable {
         let tag_name: String
@@ -143,6 +157,9 @@ final class UpdateChecker: ObservableObject {
                 latestVersion = nil
                 latestNotes = nil
             }
+            // The same response answers "what am I running?" — someone who installed by hand
+            // gets their notes from the first check after, without waiting for a next release.
+            installedNotes = Self.installedNotes(current: currentVersion)
         } catch {
             // Silent: a failed background check shouldn't surface as an error — only an
             // explicit download attempt should show one. But do surface what the last
@@ -167,6 +184,58 @@ final class UpdateChecker: ObservableObject {
         UserDefaults.standard.set(version, forKey: Self.dismissedKey)
         latestVersion = nil
         latestNotes = nil
+    }
+
+    /// Works out whether this launch is the first on a new version, and loads the notes for
+    /// whatever is running. Call once, at startup.
+    ///
+    /// Recording the version is unconditional and happens here rather than at quit: an app
+    /// that is killed, crashes, or is replaced under itself never gets a clean shutdown, and
+    /// the one thing worse than a missed announcement is the same one every launch.
+    func loadInstalledVersionState() {
+        let defaults = UserDefaults.standard
+        let current = currentVersion
+        let lastRun = defaults.string(forKey: Self.lastRunVersionKey)
+        if UpdateAnnouncement.shouldAnnounce(lastRun: lastRun,
+                                             current: current,
+                                             dismissed: defaults.string(forKey: Self.dismissedAnnouncementKey)) {
+            justUpdatedTo = current
+        }
+        defaults.set(current, forKey: Self.lastRunVersionKey)
+        installedNotes = Self.installedNotes(current: current)
+    }
+
+    func dismissAnnouncement() {
+        if let version = justUpdatedTo {
+            UserDefaults.standard.set(version, forKey: Self.dismissedAnnouncementKey)
+        }
+        justUpdatedTo = nil
+    }
+
+    /// The cached notes, but only when they are demonstrably about the version running.
+    ///
+    /// Every successful check stores the latest release's version and body together, whether
+    /// or not it was newer — so this answers for someone who installed the DMG by hand too,
+    /// from the first check after they did. A mismatch means the cache is about some other
+    /// release and showing it would be worse than showing nothing.
+    /// The same notes, for a caller with no `UpdateChecker` to hand — the About window, which
+    /// observes nothing and is built fresh each time it opens.
+    static func notesForRunningVersion() -> ReleaseNotes? {
+        installedNotes(current: AppInfo.comparableVersion)
+    }
+
+    private static func installedNotes(current: String) -> ReleaseNotes? {
+        let defaults = UserDefaults.standard
+        return notes(for: current,
+                     cachedVersion: defaults.string(forKey: lastFoundKey),
+                     cachedBody: defaults.string(forKey: lastFoundNotesKey))
+    }
+
+    /// The rule, kept apart from the defaults it reads so it can be stated in a test: notes
+    /// are shown only when the cache is demonstrably about this exact version.
+    static func notes(for current: String, cachedVersion: String?, cachedBody: String?) -> ReleaseNotes? {
+        guard cachedVersion == current else { return nil }
+        return notes(from: cachedBody)
     }
 
     /// Parsed once here rather than in the view: `body` is a couple of kilobytes of prose and
@@ -314,6 +383,13 @@ final class UpdateChecker: ObservableObject {
         latestVersion = version
         self.phase = phase
         latestNotes = Self.notes(from: notes)
+    }
+
+    /// Pins the "Updated to …" card open for `render-ui updated`, which otherwise only appears
+    /// on the one launch that follows an install.
+    func loadPreviewUpdated(version: String = AppInfo.comparableVersion, notes: String? = nil) {
+        justUpdatedTo = version
+        installedNotes = Self.notes(from: notes)
     }
 }
 

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -198,11 +198,26 @@ final class UpdateChecker: ObservableObject {
         let lastRun = defaults.string(forKey: Self.lastRunVersionKey)
         if UpdateAnnouncement.shouldAnnounce(lastRun: lastRun,
                                              current: current,
-                                             dismissed: defaults.string(forKey: Self.dismissedAnnouncementKey)) {
+                                             dismissed: defaults.string(forKey: Self.dismissedAnnouncementKey),
+                                             hasRunBefore: Self.hasRunBefore(defaults)) {
             justUpdatedTo = current
         }
         defaults.set(current, forKey: Self.lastRunVersionKey)
         installedNotes = Self.installedNotes(current: current)
+    }
+
+    /// Evidence that some version of MacRazer has run on this machine before.
+    ///
+    /// Asked only when no version was recorded, which happens exactly once per install: the
+    /// upgrade from a build older than this bookkeeping. Both keys predate it — the update
+    /// check has written its date since 0.2.0, and the login-item default has recorded itself
+    /// since 0.3.0 — so between them they cover anyone who has either been online once or run
+    /// from an installed bundle once. Someone who has done neither is announced nothing, which
+    /// is the same thing a genuinely new install gets, and the About window still has the
+    /// notes.
+    private static func hasRunBefore(_ defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: lastCheckKey) != nil
+            || defaults.object(forKey: LaunchAtLogin.appliedDefaultKey) != nil
     }
 
     func dismissAnnouncement() {

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -36,6 +36,11 @@ final class UpdateChecker: ObservableObject {
     /// check has nothing to say while it runs.
     @Published private(set) var isChecking = false
 
+    /// Notes for `latestVersion`, parsed for the popover. Nil when the release had no body or
+    /// nothing has been found — the "What's new" row hides itself rather than opening onto an
+    /// empty page.
+    @Published private(set) var latestNotes: ReleaseNotes?
+
     /// The error from the last failed install, kept raw (not just its message) so
     /// `AutoInstallPolicy` can tell a dropped connection from a payload that will never work.
     private(set) var lastInstallError: Error?
@@ -68,9 +73,13 @@ final class UpdateChecker: ObservableObject {
     private static let lastCheckKey = "lastUpdateCheckDate"
     private static let lastFoundKey = "lastFoundUpdateVersion"
     private static let autoInstallKey = "autoInstallUpdates"
+    private static let lastFoundNotesKey = "lastFoundUpdateNotes"
 
     private struct GitHubRelease: Decodable {
         let tag_name: String
+        /// The release notes. Optional because a release can be published without a body, and
+        /// a missing one must not fail the version check that is the point of this request.
+        let body: String?
     }
 
     var currentVersion: String { AppInfo.comparableVersion }
@@ -124,12 +133,15 @@ final class UpdateChecker: ObservableObject {
             let checkedAt = Date()
             UserDefaults.standard.set(checkedAt, forKey: Self.lastCheckKey)
             UserDefaults.standard.set(remote, forKey: Self.lastFoundKey)
+            UserDefaults.standard.set(release.body ?? "", forKey: Self.lastFoundNotesKey)
             lastCheckedAt = checkedAt
             let dismissed = UserDefaults.standard.string(forKey: Self.dismissedKey)
             if Self.isNewer(remote, than: currentVersion), remote != dismissed {
                 latestVersion = remote
+                latestNotes = Self.notes(from: release.body)
             } else {
                 latestVersion = nil
+                latestNotes = nil
             }
         } catch {
             // Silent: a failed background check shouldn't surface as an error — only an
@@ -147,12 +159,22 @@ final class UpdateChecker: ObservableObject {
         let dismissed = UserDefaults.standard.string(forKey: Self.dismissedKey)
         if Self.isNewer(found, than: currentVersion), found != dismissed {
             latestVersion = found
+            latestNotes = Self.notes(from: UserDefaults.standard.string(forKey: Self.lastFoundNotesKey))
         }
     }
 
     func dismiss(_ version: String) {
         UserDefaults.standard.set(version, forKey: Self.dismissedKey)
         latestVersion = nil
+        latestNotes = nil
+    }
+
+    /// Parsed once here rather than in the view: `body` is a couple of kilobytes of prose and
+    /// a SwiftUI body can run many times a second.
+    private static func notes(from body: String?) -> ReleaseNotes? {
+        guard let body, !body.isEmpty else { return nil }
+        let parsed = ReleaseNotes.parse(body)
+        return parsed.isEmpty ? nil : parsed
     }
 
     // MARK: - Installing
@@ -288,9 +310,10 @@ final class UpdateChecker: ObservableObject {
 
     /// Pins the update card open for the `render-ui` preview, which otherwise only shows it on
     /// the rare day a real release is newer than the running build.
-    func loadPreviewState(version: String = "9.9.9", phase: Phase = .idle) {
+    func loadPreviewState(version: String = "9.9.9", phase: Phase = .idle, notes: String? = nil) {
         latestVersion = version
         self.phase = phase
+        latestNotes = Self.notes(from: notes)
     }
 }
 

--- a/Sources/MacRazer/WhatsNewPage.swift
+++ b/Sources/MacRazer/WhatsNewPage.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import SwiftUI
+
+/// The release notes for a pending update, given the whole popover.
+///
+/// A sub-page rather than an expanding section in the update card: the main page already
+/// fills the height a menu bar popover can reasonably use, so notes shown inline would push
+/// the cards below them off screen. Reached from one chevron row in the card, the same way
+/// Buttons, Usage and Profiles are reached.
+struct WhatsNewPage: View {
+    let version: String
+    let notes: ReleaseNotes
+    /// Drives the button's wording: an in-place install ends in a relaunch, a plain download
+    /// doesn't, and the button should never promise the restart it can't deliver.
+    let canInstallInPlace: Bool
+    let onBack: () -> Void
+    let onUpdate: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left").font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.razerGreen)
+                Text("What's new in \(version)").font(.system(size: 13, weight: .semibold))
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if !notes.summary.isEmpty {
+                        Text(notes.summary)
+                            .font(.system(size: 11.5))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    // Indexed rather than keyed by title: nothing stops a release body from
+                    // using the same heading twice, and the untitled section has no key at all.
+                    ForEach(Array(notes.sections.enumerated()), id: \.offset) { _, section in
+                        VStack(alignment: .leading, spacing: 8) {
+                            if !section.title.isEmpty {
+                                Text(section.title.uppercased())
+                                    .font(.system(size: 9.5, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                                    .kerning(0.6)
+                            }
+                            // Indexed: two releases can carry the same headline, and an
+                            // identical bullet twice in one section is legal markdown.
+                            ForEach(Array(section.items.enumerated()), id: \.offset) { _, item in
+                                itemRow(item)
+                            }
+                        }
+                    }
+                    Link("Full release notes", destination: ProjectLinks.latestRelease)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.razerGreen)
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Repeated from the card so the decision can be made where the information is,
+            // without navigating back to find the button again.
+            Button(action: onUpdate) {
+                HStack(spacing: 6) {
+                    Image(systemName: canInstallInPlace ? "arrow.triangle.2.circlepath" : "arrow.down.to.line")
+                    Text(canInstallInPlace ? "Update & Restart" : "Download")
+                }
+                .font(.system(size: 11.5, weight: .medium))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.razerGreen)
+            .controlSize(.small)
+            .padding(12)
+        }
+    }
+
+    @ViewBuilder
+    private func itemRow(_ item: ReleaseNotes.Item) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if !item.headline.isEmpty {
+                Text(item.headline)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if !item.detail.isEmpty {
+                Text(item.detail)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}

--- a/Sources/MacRazer/WhatsNewPage.swift
+++ b/Sources/MacRazer/WhatsNewPage.swift
@@ -16,7 +16,9 @@ struct WhatsNewPage: View {
     /// doesn't, and the button should never promise the restart it can't deliver.
     let canInstallInPlace: Bool
     let onBack: () -> Void
-    let onUpdate: () -> Void
+    /// Nil when there is nothing to install — the notes are about the version already running,
+    /// and a button offering to fetch it again would be nonsense.
+    let onUpdate: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -68,19 +70,21 @@ struct WhatsNewPage: View {
 
             // Repeated from the card so the decision can be made where the information is,
             // without navigating back to find the button again.
-            Button(action: onUpdate) {
-                HStack(spacing: 6) {
-                    Image(systemName: canInstallInPlace ? "arrow.triangle.2.circlepath" : "arrow.down.to.line")
-                    Text(canInstallInPlace ? "Update & Restart" : "Download")
+            if let onUpdate {
+                Button(action: onUpdate) {
+                    HStack(spacing: 6) {
+                        Image(systemName: canInstallInPlace ? "arrow.triangle.2.circlepath" : "arrow.down.to.line")
+                        Text(canInstallInPlace ? "Update & Restart" : "Download")
+                    }
+                    .font(.system(size: 11.5, weight: .medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 5)
                 }
-                .font(.system(size: 11.5, weight: .medium))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 5)
+                .buttonStyle(.borderedProminent)
+                .tint(.razerGreen)
+                .controlSize(.small)
+                .padding(12)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.razerGreen)
-            .controlSize(.small)
-            .padding(12)
         }
     }
 

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -164,34 +164,13 @@ case "render-ui":
     // Render the popover to a PNG for static visual inspection (no device needed).
     _ = NSApplication.shared
     let path = outputPath(args.dropFirst(), default: "ui-preview.png")
-    // Real v0.3.0 notes, so `render-ui update` shows the page at the length releases actually
-    // reach rather than a tidy sample. Declared here rather than at file scope: it is preview
-    // copy, and a top-level `let` runs — and ships — in the menu bar app too.
-    let previewReleaseBody = """
-MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
-
-### Added
-- **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
-- **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it, checks it, replaces itself and relaunches. No more dragging a DMG.
-- **"Install updates automatically"**, off by default. It never starts while the popover or a window is open, since installing ends in a relaunch.
-- **A Settings window**, reached from the right-click menu or the gear in the footer.
-- **An About window**, with the licence and proper credit to OpenRazer.
-- The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
-
-### Fixed
-- Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
-
-### Install
-This build is unsigned, so first launch shows the standard Gatekeeper warning.
-
-**Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
-"""
     let controller = MouseController()
     controller.loadPreviewState()
     if args.contains("offline") { controller.setPreviewOffline() }
     if args.contains("bluetooth") { controller.setPreviewBluetooth() }
     let updateChecker = UpdateChecker()
-    if args.contains("update") { updateChecker.loadPreviewState(notes: previewReleaseBody) }
+    if args.contains("update") { updateChecker.loadPreviewState(notes: PreviewNotes.releaseBody) }
+    if args.contains("updated") { updateChecker.loadPreviewUpdated(notes: PreviewNotes.releaseBody) }
     if args.contains("downloading") { updateChecker.loadPreviewState(phase: .downloading(0.42)) }
     let launchAtLogin = LaunchAtLogin()
     launchAtLogin.loadPreviewState()
@@ -199,11 +178,19 @@ This build is unsigned, so first launch shows the standard Gatekeeper warning.
     // and it is sized to the height the main page renders at — the whole point of checking
     // it is whether the notes fit there.
     if args.contains("whatsnew") {
-        updateChecker.loadPreviewState(notes: previewReleaseBody)
-        writeHostedPNG(WhatsNewPage(version: updateChecker.latestVersion ?? "0.0.0",
-                                    notes: updateChecker.latestNotes ?? ReleaseNotes.parse(previewReleaseBody),
+        // `installed` is the same page reached from the "Updated to …" card: same notes, no
+        // button, because there is nothing left to install.
+        let installed = args.contains("installed")
+        if installed {
+            updateChecker.loadPreviewUpdated(notes: PreviewNotes.releaseBody)
+        } else {
+            updateChecker.loadPreviewState(notes: PreviewNotes.releaseBody)
+        }
+        writeHostedPNG(WhatsNewPage(version: updateChecker.latestVersion ?? AppInfo.displayVersion,
+                                    notes: (installed ? updateChecker.installedNotes : updateChecker.latestNotes)
+                                        ?? ReleaseNotes.parse(PreviewNotes.releaseBody),
                                     canInstallInPlace: updateChecker.canInstallInPlace,
-                                    onBack: {}, onUpdate: {}),
+                                    onBack: {}, onUpdate: installed ? nil : {}),
                        size: CGSize(width: 320, height: 748), to: path)
         break
     }
@@ -234,7 +221,11 @@ case "render-settings":
 case "render-about":
     _ = NSApplication.shared
     let aboutPath = outputPath(args.dropFirst(), default: "about-preview.png")
-    writeViewPNG(AboutView(onDone: {}), to: aboutPath) // no window to close in a render
+    // `notes` shows the "What's new in …" row, which is otherwise only there once the app has
+    // cached a release body.
+    writeViewPNG(AboutView(onDone: {}, // no window to close in a render
+                           notes: args.contains("notes") ? ReleaseNotes.parse(PreviewNotes.releaseBody) : nil),
+                 to: aboutPath)
 
 case "render-remap":
     _ = NSApplication.shared

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -15,28 +15,6 @@ import SwiftUI
 
 let args = Array(CommandLine.arguments.dropFirst())
 
-/// Real v0.3.0 notes, so `render-ui update` shows the page at the length releases actually
-/// reach rather than a tidy sample.
-let previewReleaseBody = """
-MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
-
-### Added
-- **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
-- **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it, checks it, replaces itself and relaunches. No more dragging a DMG.
-- **"Install updates automatically"**, off by default. It never starts while the popover or a window is open, since installing ends in a relaunch.
-- **A Settings window**, reached from the right-click menu or the gear in the footer.
-- **An About window**, with the licence and proper credit to OpenRazer.
-- The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
-
-### Fixed
-- Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
-
-### Install
-This build is unsigned, so first launch shows the standard Gatekeeper warning.
-
-**Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
-"""
-
 // No arguments → launch the menu bar app. Subcommands → run the CLI diagnostics below.
 if args.isEmpty {
     let app = NSApplication.shared
@@ -127,6 +105,16 @@ func openDevice() -> HIDDevice? {
     print("Wrote \(path)")
 }
 
+/// The output path for a `render-*` command: the first argument that names a PNG.
+///
+/// Flags are bare words and the path is positional, so "the first argument" wrote a file
+/// literally named `update` or `charging`. Keeping a list of known flags per command only
+/// moves the bug — a flag added later and forgotten in the list becomes the filename again.
+/// Asking what the argument *is* needs no list to keep in sync.
+func outputPath(_ args: ArraySlice<String>, default fallback: String) -> String {
+    args.first { $0.lowercased().hasSuffix(".png") } ?? fallback
+}
+
 switch command {
 case "info":
     // List every HID interface the dongle exposes, so we can see which one is the control
@@ -175,11 +163,29 @@ case "login-item":
 case "render-ui":
     // Render the popover to a PNG for static visual inspection (no device needed).
     _ = NSApplication.shared
-    // Flags are bare words, so they must be excluded from the positional path — otherwise
-    // `render-ui update` writes a file literally named "update".
-    let uiFlags: Set<String> = ["offline", "bluetooth", "update", "downloading",
-                                "color", "usage", "profiles", "whatsnew"]
-    let path = args.dropFirst().first { !uiFlags.contains($0) } ?? "ui-preview.png"
+    let path = outputPath(args.dropFirst(), default: "ui-preview.png")
+    // Real v0.3.0 notes, so `render-ui update` shows the page at the length releases actually
+    // reach rather than a tidy sample. Declared here rather than at file scope: it is preview
+    // copy, and a top-level `let` runs — and ships — in the menu bar app too.
+    let previewReleaseBody = """
+MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
+
+### Added
+- **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
+- **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it, checks it, replaces itself and relaunches. No more dragging a DMG.
+- **"Install updates automatically"**, off by default. It never starts while the popover or a window is open, since installing ends in a relaunch.
+- **A Settings window**, reached from the right-click menu or the gear in the footer.
+- **An About window**, with the licence and proper credit to OpenRazer.
+- The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
+
+### Fixed
+- Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
+
+### Install
+This build is unsigned, so first launch shows the standard Gatekeeper warning.
+
+**Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
+"""
     let controller = MouseController()
     controller.loadPreviewState()
     if args.contains("offline") { controller.setPreviewOffline() }
@@ -213,7 +219,7 @@ case "render-ui":
 
 case "render-settings":
     _ = NSApplication.shared
-    let settingsPath = args.dropFirst().first { $0 != "update" } ?? "settings-preview.png"
+    let settingsPath = outputPath(args.dropFirst(), default: "settings-preview.png")
     let sc = MouseController()
     sc.loadPreviewState()
     let sl = LaunchAtLogin()
@@ -227,19 +233,19 @@ case "render-settings":
 
 case "render-about":
     _ = NSApplication.shared
-    let aboutPath = args.dropFirst().first ?? "about-preview.png"
+    let aboutPath = outputPath(args.dropFirst(), default: "about-preview.png")
     writeViewPNG(AboutView(onDone: {}), to: aboutPath) // no window to close in a render
 
 case "render-remap":
     _ = NSApplication.shared
-    let path = args.dropFirst().first ?? "remap-preview.png"
+    let path = outputPath(args.dropFirst(), default: "remap-preview.png")
     let r = ButtonRemapper()
     r.loadPreviewState()
     writeViewPNG(RemapView(remapper: r), to: path)
 
 case "render-permissions":
     _ = NSApplication.shared
-    let path = args.dropFirst().first ?? "permissions-preview.png"
+    let path = outputPath(args.dropFirst(), default: "permissions-preview.png")
     let controller = MouseController()
     controller.loadPreviewState()
     let model = PermissionsModel()
@@ -248,11 +254,8 @@ case "render-permissions":
 
 case "icon":
     // Render the menu bar mark to a PNG for visual inspection.
-    // Flags and the optional size are bare words, so they must be excluded from the
-    // positional path — otherwise `icon charging` writes a file literally named "charging".
-    let iconFlags: Set<String> = ["charging", "nologo", "light"]
     let iconArgs = args.dropFirst()
-    let path = iconArgs.first { !iconFlags.contains($0) && Int($0) == nil } ?? "icon-preview.png"
+    let path = outputPath(iconArgs, default: "icon-preview.png")
     // Optional size, so the mark can be checked at real menu bar scale (~21pt @2x) rather
     // than judged from a downsampled 256px render. Bounded: an unbounded value makes the
     // bitmap allocation fail and the write silently do nothing.

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -15,6 +15,28 @@ import SwiftUI
 
 let args = Array(CommandLine.arguments.dropFirst())
 
+/// Real v0.3.0 notes, so `render-ui update` shows the page at the length releases actually
+/// reach rather than a tidy sample.
+let previewReleaseBody = """
+MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
+
+### Added
+- **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
+- **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it, checks it, replaces itself and relaunches. No more dragging a DMG.
+- **"Install updates automatically"**, off by default. It never starts while the popover or a window is open, since installing ends in a relaunch.
+- **A Settings window**, reached from the right-click menu or the gear in the footer.
+- **An About window**, with the licence and proper credit to OpenRazer.
+- The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
+
+### Fixed
+- Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
+
+### Install
+This build is unsigned, so first launch shows the standard Gatekeeper warning.
+
+**Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
+"""
+
 // No arguments → launch the menu bar app. Subcommands → run the CLI diagnostics below.
 if args.isEmpty {
     let app = NSApplication.shared
@@ -78,6 +100,33 @@ func openDevice() -> HIDDevice? {
     }
 }
 
+/// Renders through a real `NSHostingView` instead of `ImageRenderer`.
+///
+/// `ImageRenderer` draws a `ScrollView` as an empty box — its content is laid out lazily and
+/// never makes it into the snapshot — so a page whose body is a scroll view has to be hosted
+/// in a view hierarchy and captured from there. Fixed size, because a hosting view has no
+/// window to size it.
+@MainActor func writeHostedPNG<V: View>(_ view: V, size: CGSize, to path: String) {
+    // The popover's own backdrop. `cacheDisplay` captures no window background, and the dark
+    // scheme's primary text is white — without this the whole page renders white on white.
+    let hosted = view.environment(\.colorScheme, .dark).background(Color(white: 0.13))
+    let host = NSHostingView(rootView: AnyView(hosted))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = CGRect(origin: .zero, size: size)
+    host.layoutSubtreeIfNeeded()
+    guard let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+        print("Render failed")
+        return
+    }
+    host.cacheDisplay(in: host.bounds, to: rep)
+    guard let png = rep.representation(using: .png, properties: [:]) else {
+        print("Render failed")
+        return
+    }
+    try? png.write(to: URL(fileURLWithPath: path))
+    print("Wrote \(path)")
+}
+
 switch command {
 case "info":
     // List every HID interface the dongle exposes, so we can see which one is the control
@@ -126,16 +175,32 @@ case "login-item":
 case "render-ui":
     // Render the popover to a PNG for static visual inspection (no device needed).
     _ = NSApplication.shared
-    let path = args.dropFirst().first ?? "ui-preview.png"
+    // Flags are bare words, so they must be excluded from the positional path — otherwise
+    // `render-ui update` writes a file literally named "update".
+    let uiFlags: Set<String> = ["offline", "bluetooth", "update", "downloading",
+                                "color", "usage", "profiles", "whatsnew"]
+    let path = args.dropFirst().first { !uiFlags.contains($0) } ?? "ui-preview.png"
     let controller = MouseController()
     controller.loadPreviewState()
     if args.contains("offline") { controller.setPreviewOffline() }
     if args.contains("bluetooth") { controller.setPreviewBluetooth() }
     let updateChecker = UpdateChecker()
-    if args.contains("update") { updateChecker.loadPreviewState() }
+    if args.contains("update") { updateChecker.loadPreviewState(notes: previewReleaseBody) }
     if args.contains("downloading") { updateChecker.loadPreviewState(phase: .downloading(0.42)) }
     let launchAtLogin = LaunchAtLogin()
     launchAtLogin.loadPreviewState()
+    // The notes page is its own render: it is a scroll view, so it needs the hosted path,
+    // and it is sized to the height the main page renders at — the whole point of checking
+    // it is whether the notes fit there.
+    if args.contains("whatsnew") {
+        updateChecker.loadPreviewState(notes: previewReleaseBody)
+        writeHostedPNG(WhatsNewPage(version: updateChecker.latestVersion ?? "0.0.0",
+                                    notes: updateChecker.latestNotes ?? ReleaseNotes.parse(previewReleaseBody),
+                                    canInstallInPlace: updateChecker.canInstallInPlace,
+                                    onBack: {}, onUpdate: {}),
+                       size: CGSize(width: 320, height: 748), to: path)
+        break
+    }
     let rootView: AnyView = args.contains("color")
         ? AnyView(ColorPickerPage(color: .constant(.blue), onBack: {}, onApply: { _ in }))
         : args.contains("usage")

--- a/Tests/MacRazerTests/ReleaseNotesTests.swift
+++ b/Tests/MacRazerTests/ReleaseNotesTests.swift
@@ -98,6 +98,12 @@ final class ReleaseNotesTests: XCTestCase {
         }
     }
 
+    func testTheDashAfterABoldLeadGoesWithIt() {
+        let i = ReleaseNotes.item(from: "**Orochi 2013** — verified over Bluetooth.")
+        XCTAssertEqual(i.headline, "Orochi 2013")
+        XCTAssertEqual(i.detail, "verified over Bluetooth.")
+    }
+
     func testMarkdownMarkersAreStripped() {
         XCTAssertEqual(ReleaseNotes.strip("a **bold** and `code`"), "a bold and code")
         XCTAssertEqual(ReleaseNotes.strip("see [the docs](https://example.com) here"), "see the docs here")
@@ -151,6 +157,34 @@ final class ReleaseNotesTests: XCTestCase {
         """)
         XCTAssertEqual(notes.sections.first?.items.count, 1)
         XCTAssertEqual(notes.sections.first?.items.first?.detail, "It does something.")
+    }
+
+    /// The two halves have to agree: `Scripts/release-notes.sh` decides the shape of every
+    /// future release body, and this decides what that shape turns into on screen. They are a
+    /// shell script and a Swift struct with no compiler between them, so the agreement is only
+    /// as good as a test that states it.
+    func testTheShapeReleaseNotesShDraftsParsesAsIntended() {
+        let drafted = """
+        MacRazer now starts at login and installs its own updates.
+
+        ### Added
+        - **A new thing.** It does something.
+
+        ### Thanks
+        - **@caseyc** — Add support for the thing (#5)
+
+        ### Install
+        This build is unsigned (no paid Apple Developer ID), so first launch shows the standard
+        Gatekeeper warning.
+
+        **Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
+        """
+        let notes = ReleaseNotes.parse(drafted)
+        XCTAssertEqual(notes.summary, "MacRazer now starts at login and installs its own updates.")
+        XCTAssertEqual(notes.sections.map(\.title), ["Added", "Thanks"])
+        // Contributors are credited in the app, not only on the releases page.
+        XCTAssertEqual(notes.sections.last?.items.first?.headline, "@caseyc")
+        XCTAssertEqual(notes.sections.last?.items.first?.detail, "Add support for the thing (#5)")
     }
 
     func testEmptyBodyIsEmptyNotACrash() {

--- a/Tests/MacRazerTests/ReleaseNotesTests.swift
+++ b/Tests/MacRazerTests/ReleaseNotesTests.swift
@@ -109,6 +109,58 @@ final class ReleaseNotesTests: XCTestCase {
         XCTAssertEqual(ReleaseNotes.strip("see [the docs](https://example.com) here"), "see the docs here")
     }
 
+    func testAStrayBracketDoesNotSwallowTheTextAfterIt() {
+        // Pairing the first `[` with the first later `](` destroyed everything between them.
+        // Release bodies now carry changelog prose verbatim, and that prose has brackets in it.
+        XCTAssertEqual(ReleaseNotes.strip("a [ b [c](https://e.com)"), "a [ b c")
+        XCTAssertEqual(ReleaseNotes.strip("an unclosed [ bracket"), "an unclosed [ bracket")
+        XCTAssertEqual(ReleaseNotes.strip("two [one](https://a.com) and [two](https://b.com)"),
+                       "two one and two")
+    }
+
+    // MARK: Prose the body wraps, and prose that isn't the summary
+
+    func testAWrappedSummaryIsOneParagraph() {
+        // Every markdown file in this repo is hard-wrapped and the drafted template wraps too,
+        // so a summary split across source lines is the normal case, not an edge one. Joining
+        // them with a paragraph break put a blank line through the middle of a sentence.
+        let notes = ReleaseNotes.parse("""
+        MacRazer now starts at login and installs its own updates, with Settings
+        and About windows to go with them.
+
+        ### Added
+        - **A thing.** Yes.
+        """)
+        XCTAssertEqual(notes.summary,
+                       "MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.")
+    }
+
+    func testABlankLineStillStartsANewParagraph() {
+        let notes = ReleaseNotes.parse("""
+        First paragraph, wrapped
+        across two lines.
+
+        > A callout after a blank line.
+
+        ### Added
+        - **A thing.** Yes.
+        """)
+        XCTAssertEqual(notes.summary, "First paragraph, wrapped across two lines.\n\nA callout after a blank line.")
+    }
+
+    func testProseAfterTheBulletsStaysOutOfTheSummary() {
+        // Reachable since a body with no headings at all became supported: the summary branch
+        // used to accept any non-bullet line while no heading had been seen, which hoisted a
+        // closing sentence to the top of the page, above the bullets it was written under.
+        let notes = ReleaseNotes.parse("""
+        - first thing
+        - second thing
+        See the README for details.
+        """)
+        XCTAssertEqual(notes.summary, "")
+        XCTAssertEqual(notes.sections.first?.items.count, 2)
+    }
+
     // MARK: Shapes a future release body could arrive in
 
     func testGeneratedNotesUseHashHashAndAsterisks() {

--- a/Tests/MacRazerTests/ReleaseNotesTests.swift
+++ b/Tests/MacRazerTests/ReleaseNotesTests.swift
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+final class ReleaseNotesTests: XCTestCase {
+    /// The real v0.3.0 body, verbatim. The parser's input is prose written by hand months
+    /// apart, so the fixture is a released artefact rather than something shaped to pass.
+    private let realBody = """
+    MacRazer now starts at login and installs its own updates, with Settings and About windows to go with them.
+
+    > **This is the first release you can install from inside the app** — and the first time that path has run on a machine other than the developer's. If an update ever misbehaves, the DMG below always works.
+
+    ### Added
+    - **Start MacRazer at login**, on by default. A menu bar battery meter that stops existing after every reboot isn't much of a battery meter.
+    - **"Update & Restart"** in the update card. When a new version is out, MacRazer downloads it with a progress bar.
+    - **A Settings window** (right-click the menu bar icon › Settings…, or the gear in the popover footer): start at login, show battery % in the menu bar, automatic updates, and what version you're on with a Check Now button.
+    - The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle you had to look for.
+
+    ### Fixed
+    - Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt that a scripted build has nobody to click.
+
+    ### Install
+    This build is unsigned (no paid Apple Developer ID), so first launch shows the standard Gatekeeper warning.
+
+    **Full changelog:** https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md
+    """
+
+    func testKeepsTheSectionsWorthReading() {
+        let notes = ReleaseNotes.parse(realBody)
+        XCTAssertEqual(notes.sections.map(\.title), ["Added", "Fixed"],
+                       "Install is for someone who hasn't got the app running yet")
+        XCTAssertEqual(notes.sections[0].items.count, 4)
+        XCTAssertEqual(notes.sections[1].items.count, 1)
+    }
+
+    func testSummaryKeepsTheCalloutButNotItsMarkers() {
+        let notes = ReleaseNotes.parse(realBody)
+        XCTAssertTrue(notes.summary.hasPrefix("MacRazer now starts at login"))
+        XCTAssertTrue(notes.summary.contains("first release you can install from inside the app"))
+        XCTAssertFalse(notes.summary.contains(">"), "blockquote marker")
+        XCTAssertFalse(notes.summary.contains("**"), "bold markers")
+    }
+
+    func testDropsTheChangelogFooter() {
+        let notes = ReleaseNotes.parse(realBody)
+        let all = notes.summary + notes.sections.flatMap(\.items).map { $0.headline + $0.detail }.joined()
+        XCTAssertFalse(all.contains("Full changelog"))
+        XCTAssertFalse(all.contains("github.com"))
+    }
+
+    // MARK: - The four bullet shapes the real notes actually use
+
+    func testBoldLeadBecomesTheHeadline() {
+        let i = ReleaseNotes.item(from: "**Start MacRazer at login**, on by default. A menu bar battery meter that stops existing isn't much of one.")
+        XCTAssertEqual(i.headline, "Start MacRazer at login")
+        XCTAssertEqual(i.detail, "on by default. A menu bar battery meter that stops existing isn't much of one.")
+    }
+
+    func testQuotedFeatureNameSurvives() {
+        let i = ReleaseNotes.item(from: "**\"Update & Restart\"** in the update card. It downloads with a progress bar.")
+        XCTAssertEqual(i.headline, "\"Update & Restart\"")
+        XCTAssertEqual(i.detail, "in the update card. It downloads with a progress bar.")
+    }
+
+    func testNoEmphasisFallsBackToTheFirstSentence() {
+        let i = ReleaseNotes.item(from: "Builds no longer appear to hang at the codesigning step. macOS was showing a keychain prompt.")
+        XCTAssertEqual(i.headline, "Builds no longer appear to hang at the codesigning step.")
+        XCTAssertEqual(i.detail, "macOS was showing a keychain prompt.")
+    }
+
+    func testMidSentenceBoldIsNotMistakenForALead() {
+        // The bold run starts partway in, so the first sentence is the honest lead.
+        let i = ReleaseNotes.item(from: "The **charging bolt fills the mouse icon and is yellow**, instead of a grey squiggle.")
+        XCTAssertFalse(i.headline.hasPrefix("charging bolt"), "must not lift the middle of the sentence")
+        XCTAssertTrue((i.headline + i.detail).contains("charging bolt fills the mouse icon"))
+    }
+
+    func testAnOverlongLeadIsLeftWhole() {
+        // The Settings-window bullet: one sentence, far too long to set apart as a headline.
+        let long = "**A Settings window** (right-click the menu bar icon › Settings…, or the gear in the popover footer): start at login, show battery % in the menu bar, automatic updates, and what version you're on with a Check Now button."
+        let i = ReleaseNotes.item(from: long)
+        XCTAssertEqual(i.headline, "A Settings window")
+        XCTAssertTrue(i.detail.contains("Check Now button"), "nothing may be dropped")
+    }
+
+    func testNothingIsEverSilentlyLost() {
+        // Whatever the shape, every bullet's words reach the reader somewhere.
+        for bullet in ["plain sentence with no punctuation at all",
+                       "**bold only**",
+                       "A `code` span and a [link](https://example.com) inline.",
+                       ""] {
+            let i = ReleaseNotes.item(from: bullet)
+            let out = (i.headline + " " + i.detail).trimmingCharacters(in: .whitespaces)
+            let expected = ReleaseNotes.strip(bullet)
+            XCTAssertFalse(out.isEmpty && !expected.isEmpty, "dropped: '\(bullet)'")
+        }
+    }
+
+    func testMarkdownMarkersAreStripped() {
+        XCTAssertEqual(ReleaseNotes.strip("a **bold** and `code`"), "a bold and code")
+        XCTAssertEqual(ReleaseNotes.strip("see [the docs](https://example.com) here"), "see the docs here")
+    }
+
+    // MARK: Shapes a future release body could arrive in
+
+    func testGeneratedNotesUseHashHashAndAsterisks() {
+        // What GitHub's "Generate release notes" button emits. Nothing in the app forces the
+        // hand-written style, and a body whose headings and bullets all went unrecognised
+        // would arrive as one undifferentiated paragraph.
+        let notes = ReleaseNotes.parse("""
+        ## What's Changed
+        * Fix the brightness slider by @someone in #21
+        * Add two mice by @other in #22
+        """)
+        XCTAssertEqual(notes.sections.count, 1)
+        XCTAssertEqual(notes.sections.first?.title, "What's Changed")
+        XCTAssertEqual(notes.sections.first?.items.count, 2)
+    }
+
+    func testAListWithNoHeadingIsStillShown() {
+        let notes = ReleaseNotes.parse("""
+        - **First thing.** It happened.
+        - **Second thing.** So did this.
+        """)
+        XCTAssertEqual(notes.sections.count, 1)
+        XCTAssertEqual(notes.sections.first?.title, "")
+        // The period is inside the bold run, so it stays with the headline — the parser
+        // reports the author's emphasis rather than re-punctuating it.
+        XCTAssertEqual(notes.sections.first?.items.map(\.headline), ["First thing.", "Second thing."])
+    }
+
+    func testAWrappedBulletKeepsItsSecondHalf() {
+        let notes = ReleaseNotes.parse("""
+        ### Fixed
+        - **Brightness on scroll-wheel mice.** The LED group was hardcoded,
+          so the slider silently did nothing.
+        """)
+        XCTAssertEqual(notes.sections.first?.items.count, 1)
+        XCTAssertEqual(notes.sections.first?.items.first?.detail,
+                       "The LED group was hardcoded, so the slider silently did nothing.")
+    }
+
+    func testAParagraphAfterABlankLineIsNotGluedOntoTheBullet() {
+        let notes = ReleaseNotes.parse("""
+        ### Added
+        - **A thing.** It does something.
+
+        See the README for the details.
+        """)
+        XCTAssertEqual(notes.sections.first?.items.count, 1)
+        XCTAssertEqual(notes.sections.first?.items.first?.detail, "It does something.")
+    }
+
+    func testEmptyBodyIsEmptyNotACrash() {
+        XCTAssertTrue(ReleaseNotes.parse("").isEmpty)
+        XCTAssertTrue(ReleaseNotes.parse("\n\n").isEmpty)
+    }
+}

--- a/Tests/MacRazerTests/UpdateAnnouncementTests.swift
+++ b/Tests/MacRazerTests/UpdateAnnouncementTests.swift
@@ -52,6 +52,43 @@ final class UpdateAnnouncementTests: XCTestCase {
             lastRun: nil, current: "0.3.1", dismissed: "0.3.1", hasRunBefore: true))
     }
 
+    // MARK: Surviving until it is actually seen
+
+    func testAnAnnouncementIsOwedUntilItIsDismissed() {
+        // The launch that notices the change owes one...
+        XCTAssertEqual(UpdateAnnouncement.pending(lastRun: "0.3.0", current: "0.3.1", dismissed: nil,
+                                                  storedPending: nil, hasRunBefore: true), "0.3.1")
+        // ...and every launch after still owes it, because the card waits for the popover to be
+        // opened and a menu bar app can go days without that. Holding it in memory only meant a
+        // reboot in between lost it, on exactly the automatic-install path it exists for.
+        XCTAssertEqual(UpdateAnnouncement.pending(lastRun: "0.3.1", current: "0.3.1", dismissed: nil,
+                                                  storedPending: "0.3.1", hasRunBefore: true), "0.3.1")
+    }
+
+    func testDismissingEndsIt() {
+        XCTAssertNil(UpdateAnnouncement.pending(lastRun: "0.3.1", current: "0.3.1", dismissed: "0.3.1",
+                                                storedPending: nil, hasRunBefore: true))
+    }
+
+    func testNothingIsOwedWhenNothingChanged() {
+        XCTAssertNil(UpdateAnnouncement.pending(lastRun: "0.3.1", current: "0.3.1", dismissed: nil,
+                                                storedPending: nil, hasRunBefore: true))
+    }
+
+    func testAPendingAnnouncementForAnotherVersionIsStale() {
+        // Rolled back, or updated again before reading it. Either way the version running is
+        // the only one worth talking about, and 0.3.1's card on a 0.3.0 app would be wrong.
+        XCTAssertEqual(UpdateAnnouncement.pending(lastRun: "0.3.1", current: "0.3.2", dismissed: nil,
+                                                  storedPending: "0.3.1", hasRunBefore: true), "0.3.2")
+        XCTAssertNil(UpdateAnnouncement.pending(lastRun: "0.3.0", current: "0.3.0", dismissed: nil,
+                                                storedPending: "0.3.1", hasRunBefore: true))
+    }
+
+    func testAFirstInstallOwesNothing() {
+        XCTAssertNil(UpdateAnnouncement.pending(lastRun: nil, current: "0.3.1", dismissed: nil,
+                                                storedPending: nil, hasRunBefore: false))
+    }
+
     func testADowngradeIsStillAChange() {
         // Rolling back to a DMG after a bad release is a version change like any other, and
         // the notes for what you are now running are the useful thing to offer.

--- a/Tests/MacRazerTests/UpdateAnnouncementTests.swift
+++ b/Tests/MacRazerTests/UpdateAnnouncementTests.swift
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+final class UpdateAnnouncementTests: XCTestCase {
+    func testAVersionChangeIsAnnounced() {
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.0", current: "0.3.1", dismissed: nil))
+    }
+
+    func testTheSameVersionIsNot() {
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.1", dismissed: nil))
+    }
+
+    func testAFirstInstallIsNotAnUpdate() {
+        // Nothing recorded means nobody has run an older version here, and "Updated to 0.3.1"
+        // on the very first launch is a lie about a release the user has never seen.
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: nil, current: "0.3.1", dismissed: nil))
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "", current: "0.3.1", dismissed: nil))
+    }
+
+    func testDismissingIsPerVersion() {
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.0", current: "0.3.1", dismissed: "0.3.1"))
+        // The next release still gets to speak up.
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.2", dismissed: "0.3.1"))
+    }
+
+    func testADowngradeIsStillAChange() {
+        // Rolling back to a DMG after a bad release is a version change like any other, and
+        // the notes for what you are now running are the useful thing to offer.
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.0", dismissed: nil))
+    }
+}
+
+/// The other half of "can I still read the notes after installing?": which cached body is
+/// allowed to answer for the version now running.
+@MainActor
+final class InstalledNotesTests: XCTestCase {
+    private let body = "A summary.\n\n### Added\n- **A thing.** It happened."
+
+    func testNotesForTheVersionRunningAreShown() {
+        let notes = UpdateChecker.notes(for: "0.3.1", cachedVersion: "0.3.1", cachedBody: body)
+        XCTAssertEqual(notes?.sections.first?.items.first?.headline, "A thing.")
+    }
+
+    func testNotesCachedForAnotherVersionAreNot() {
+        // The cache tracks the newest release the last check saw, which is not always what is
+        // installed — someone who skipped 0.3.2 would otherwise read its notes in an About box
+        // that says 0.3.1.
+        XCTAssertNil(UpdateChecker.notes(for: "0.3.1", cachedVersion: "0.3.2", cachedBody: body))
+        XCTAssertNil(UpdateChecker.notes(for: "0.3.1", cachedVersion: nil, cachedBody: body))
+    }
+
+    func testAReleaseWithNoBodyShowsNothingRatherThanAnEmptyPage() {
+        XCTAssertNil(UpdateChecker.notes(for: "0.3.1", cachedVersion: "0.3.1", cachedBody: nil))
+        XCTAssertNil(UpdateChecker.notes(for: "0.3.1", cachedVersion: "0.3.1", cachedBody: ""))
+    }
+}

--- a/Tests/MacRazerTests/UpdateAnnouncementTests.swift
+++ b/Tests/MacRazerTests/UpdateAnnouncementTests.swift
@@ -6,30 +6,57 @@ import XCTest
 
 final class UpdateAnnouncementTests: XCTestCase {
     func testAVersionChangeIsAnnounced() {
-        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.0", current: "0.3.1", dismissed: nil))
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.0", current: "0.3.1", dismissed: nil, hasRunBefore: true))
     }
 
     func testTheSameVersionIsNot() {
-        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.1", dismissed: nil))
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.1", current: "0.3.1", dismissed: nil, hasRunBefore: true))
     }
 
     func testAFirstInstallIsNotAnUpdate() {
-        // Nothing recorded means nobody has run an older version here, and "Updated to 0.3.1"
-        // on the very first launch is a lie about a release the user has never seen.
-        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: nil, current: "0.3.1", dismissed: nil))
-        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "", current: "0.3.1", dismissed: nil))
+        // Nothing recorded and no trace of an older version: "Updated to 0.3.1" on the very
+        // first launch is a claim about a release the user has never seen.
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: nil, current: "0.3.1", dismissed: nil, hasRunBefore: false))
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "", current: "0.3.1", dismissed: nil, hasRunBefore: false))
+    }
+
+    func testTheUpgradeThatIntroducesTheFeatureStillAnnounces() {
+        // The case that made this parameter necessary. Someone on 0.3.0 has no recorded
+        // version, because 0.3.0 never wrote one — indistinguishable from a new install unless
+        // you look for the traces an older run left. Without this, the release that ships the
+        // announcement is the one release that never shows it.
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(
+            lastRun: nil, current: "0.3.1", dismissed: nil, hasRunBefore: true))
+    }
+
+    func testItStillOnlyHappensOnce() {
+        // Having run before stops mattering the moment a version is recorded, so the launch
+        // after the announcement is silent rather than repeating it forever.
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.1", current: "0.3.1", dismissed: nil, hasRunBefore: true))
     }
 
     func testDismissingIsPerVersion() {
-        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.0", current: "0.3.1", dismissed: "0.3.1"))
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.0", current: "0.3.1", dismissed: "0.3.1", hasRunBefore: true))
         // The next release still gets to speak up.
-        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.2", dismissed: "0.3.1"))
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.1", current: "0.3.2", dismissed: "0.3.1", hasRunBefore: true))
+        // And dismissing wins over the upgrade case too, or a dismissal on the first launch
+        // after upgrading would not stick.
+        XCTAssertFalse(UpdateAnnouncement.shouldAnnounce(
+            lastRun: nil, current: "0.3.1", dismissed: "0.3.1", hasRunBefore: true))
     }
 
     func testADowngradeIsStillAChange() {
         // Rolling back to a DMG after a bad release is a version change like any other, and
         // the notes for what you are now running are the useful thing to offer.
-        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(lastRun: "0.3.1", current: "0.3.0", dismissed: nil))
+        XCTAssertTrue(UpdateAnnouncement.shouldAnnounce(
+            lastRun: "0.3.1", current: "0.3.0", dismissed: nil, hasRunBefore: true))
     }
 }
 

--- a/Tests/Scripts/release-notes-test.sh
+++ b/Tests/Scripts/release-notes-test.sh
@@ -75,6 +75,18 @@ git checkout -q master
 git merge -q --no-ff ownwork \
     -m "Merge pull request #6 from theowner/ownwork" -m "Tidy something up"
 
+# A merge with the right prefix and the wrong shape. Its handle can't be read, and printing
+# the whole subject as one would put "@Merge pull request #7 from somebody" in the credits.
+git checkout -q -b handmade
+echo three > three.txt && git add -A && git commit -qm "Add three"
+git checkout -q master
+git merge -q --no-ff handmade -m "Merge pull request #7 from somebody" -m "No branch in the subject"
+
+# A squash-merged PR: someone else's work landing directly on master with no merge commit.
+# This is the one case the uncredited warning exists for.
+echo four > four.txt && git add -A
+git -c user.email="s@example.com" -c user.name="Sam Squash" commit -qm "Add four (#9)"
+
 cd - >/dev/null
 
 run() { (cd "${REPO}" && "${DRAFT}" "$@" 2>/dev/null); }
@@ -107,12 +119,64 @@ check "leaves out the owner's PR title too" "0" "$(echo "${OUT}" | grep -c 'Tidy
 ONLY_OWNER="$(cd "${REPO}" && "${DRAFT}" 0.3.0 --since HEAD 2>/dev/null)"
 check "no Thanks section when nobody outside contributed" "0" "$(echo "${ONLY_OWNER}" | grep -c '### Thanks')"
 
+# The warning is the only thing standing between a squash-merged PR and an uncredited
+# contributor, so it has to be believable. Matching git display names against GitHub handles
+# warned about people it had just credited, and about the maintainer whenever their user.name
+# wasn't their handle — which is most setups.
+WARNED="$(runerr 0.3.0 --since v0.2.1)"
+check "warns about a squash-merged contributor" "1" "$(echo "${WARNED}" | grep -c 'Sam Squash')"
+check "does not warn about someone it just credited" "0" "$(echo "${WARNED}" | grep -c 'Casey Contributor')"
+check "does not warn the maintainer about their own commits" "0" "$(echo "${WARNED}" | grep -c 'theowner')"
+check "reports the merge it could not parse" "1" "$(echo "${WARNED}" | grep -c "doesn't parse")"
+# This fixture has both a warning to give and a merge it can't parse, and warnings are not
+# failures — release.sh runs this and aborts the release on a non-zero exit. It did abort:
+# a warning loop whose body ended on a failing test returned that failure and `set -e` took
+# the script down with it, after the draft had already been written.
+check "warnings are not failures" "0" \
+    "$( (cd "${REPO}" && "${DRAFT}" 0.3.0 --since v0.2.1 >/dev/null 2>&1); echo $? )"
+check "does not credit an unparsable subject as a handle" "0" \
+    "$(echo "${OUT}" | grep -c '@Merge pull request')"
+
+echo "Reading the repository from any remote spelling"
+
+# `ssh://` left the owner as "ssh:", which credited the maintainer in their own notes and
+# pointed the changelog link at github.com/ssh://git@github.com/… — both without a word.
+for url in "git@github.com:theowner/Thing.git" \
+           "https://github.com/theowner/Thing.git" \
+           "ssh://git@github.com/theowner/Thing.git" \
+           "https://github.com/theowner/Thing"; do
+    ( cd "${REPO}" && git remote set-url origin "${url}" )
+    check "reads owner/repo from ${url}" "1" \
+        "$(run 0.3.0 --since v0.2.1 | grep -c 'github.com/theowner/Thing/blob/master/CHANGELOG.md')"
+done
+( cd "${REPO}" && git remote set-url origin "git@github.com:theowner/Thing.git" )
+
+check "refuses a remote it cannot read as owner/repo" "1" \
+    "$( (cd "${REPO}" && "${DRAFT}" 0.3.0 --repo "not-a-repo" >/dev/null 2>&1); echo $? )"
+
 echo "The parts that must always be there"
 
 check "leaves a placeholder for the summary" "1" "$(echo "${OUT}" | grep -c '^TODO:')"
 check "includes the install note" "1" "$(echo "${OUT}" | grep -c '^### Install')"
 check "links the full changelog at the repo it was run in" "1" \
     "$(echo "${OUT}" | grep -c 'github.com/theowner/Thing/blob/master/CHANGELOG.md')"
+
+echo "The shape ReleaseNotes.swift is written against"
+
+# The Swift side has a matching test, `testTheShapeReleaseNotesShDraftsParsesAsIntended`, but
+# it can only assert against a copy of this template — there is no compiler between a shell
+# script and a Swift struct. These assertions are the half that fails when the template moves,
+# so a rename here can't silently change what the app renders.
+check "the credits heading is exactly '### Thanks'" "1" "$(echo "${OUT}" | grep -c '^### Thanks$')"
+check "the install heading is exactly '### Install'" "1" "$(echo "${OUT}" | grep -c '^### Install$')"
+check "the footer keeps the '**Full changelog:' prefix" "1" \
+    "$(echo "${OUT}" | grep -c '^\*\*Full changelog:')"
+check "credits are bullets with a bold handle" "1" \
+    "$(echo "${OUT}" | grep -c '^- \*\*@caseyc\*\*')"
+# The parser reads everything above the first heading as the summary, so the placeholder must
+# be above it and the first heading must be a heading.
+check "the summary sits above the first heading" "1" \
+    "$(echo "${OUT}" | awk '/^#/{exit} /^TODO:/{n++} END{print n+0}')"
 
 echo "Refusing to publish a draft that is still a draft"
 

--- a/Tests/Scripts/release-notes-test.sh
+++ b/Tests/Scripts/release-notes-test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Tests for Scripts/release-notes.sh — the draft of the GitHub release body.
+#
+# Worth testing because both halves fail silently. A changelog section extracted one heading
+# too far produces a body that quietly carries the previous release's entries; a contributor
+# missed produces a release that credits nobody, and neither looks wrong on the page. The
+# credit half is also the only thing here that reads git history, so it gets a real repository
+# with real merge commits rather than a fixture of strings.
+#
+#   ./Tests/Scripts/release-notes-test.sh
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+SOURCE="$(pwd)/Scripts/release-notes.sh"
+PASS=0
+FAIL=0
+
+ok()    { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+bad()   { FAIL=$((FAIL + 1)); echo "  ✗ $1"; echo "      expected: $2"; echo "      actual:   $3"; }
+check() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "$2" "$3"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# --- A repository with a history worth reading ----------------------------------------------
+# The script resolves the repository from its own location (`cd "$(dirname "$0")/.."`), the
+# way every script in Scripts/ does, so testing it against a fixture repository means putting
+# a copy inside that repository — running the original would quietly read this one.
+REPO="${TMP}/repo"
+mkdir -p "${REPO}/Scripts"
+cp "${SOURCE}" "${REPO}/Scripts/release-notes.sh"
+DRAFT="${REPO}/Scripts/release-notes.sh"
+cd "${REPO}"
+git init -q -b master
+git config user.email "owner@example.com"
+git config user.name "theowner"
+git remote add origin "git@github.com:theowner/Thing.git"
+
+cat > CHANGELOG.md <<'MD'
+# Changelog
+
+## [Unreleased]
+
+## [0.3.0] — 2026-09-07
+
+### Added
+- **A new thing.** It does something.
+- **Another thing.** It does something else.
+
+### Fixed
+- **A bug.** It is gone.
+
+## [0.2.1] — 2026-08-01
+
+### Added
+- **An older thing.** From the release before.
+MD
+git add -A && git commit -qm "Initial"
+git tag v0.2.1
+
+# A contributor's PR, merged the way GitHub merges one.
+git checkout -q -b contribution
+echo one > one.txt && git add -A
+git -c user.email="c@example.com" -c user.name="Casey Contributor" commit -qm "Add one"
+git checkout -q master
+# Two -m flags, because that is what makes a subject and a separate body — a single -m with
+# an embedded newline is folded into one subject line, and then there is no PR title to read.
+git merge -q --no-ff contribution \
+    -m "Merge pull request #5 from caseyc/contribution" -m "Add support for the thing"
+
+# The maintainer's own PR, merged the same way. Must not be credited.
+git checkout -q -b ownwork
+echo two > two.txt && git add -A && git commit -qm "Add two"
+git checkout -q master
+git merge -q --no-ff ownwork \
+    -m "Merge pull request #6 from theowner/ownwork" -m "Tidy something up"
+
+cd - >/dev/null
+
+run() { (cd "${REPO}" && "${DRAFT}" "$@" 2>/dev/null); }
+runerr() { (cd "${REPO}" && "${DRAFT}" "$@" 2>&1 >/dev/null); }
+
+echo "Extracting the changelog section"
+
+OUT="$(run 0.3.0 --since v0.2.1)"
+check "takes the entries for the version asked for" "1" "$(echo "${OUT}" | grep -c 'A new thing')"
+check "takes every section, not just the first" "1" "$(echo "${OUT}" | grep -c 'A bug')"
+check "stops at the next release heading" "0" "$(echo "${OUT}" | grep -c 'An older thing')"
+check "does not carry the version headings into the body" "0" "$(echo "${OUT}" | grep -c '^## \[')"
+
+check "refuses a version that isn't in the changelog" "1" \
+    "$( (cd "${REPO}" && "${DRAFT}" 9.9.9 >/dev/null 2>&1); echo $? )"
+check "says which version it couldn't find" "1" \
+    "$(runerr 9.9.9 | grep -c '9.9.9')"
+
+echo "Crediting contributors"
+
+check "credits the contributor by handle" "1" "$(echo "${OUT}" | grep -c '@caseyc')"
+check "uses the PR title and number" "1" "$(echo "${OUT}" | grep -c 'Add support for the thing (#5)')"
+# A merge made by hand can have no body at all, and "@caseyc —  (#5)" reads as a mistake.
+check "no dangling dash when the merge has no PR title" "0" "$(echo "${OUT}" | grep -c -- '— *(#')"
+check "does not credit the repo owner in their own notes" "0" "$(echo "${OUT}" | grep -c '@theowner')"
+check "leaves out the owner's PR title too" "0" "$(echo "${OUT}" | grep -c 'Tidy something up')"
+
+# An empty Thanks heading is worse than none: it reads as "nobody helped" rather than as a
+# section that didn't apply.
+ONLY_OWNER="$(cd "${REPO}" && "${DRAFT}" 0.3.0 --since HEAD 2>/dev/null)"
+check "no Thanks section when nobody outside contributed" "0" "$(echo "${ONLY_OWNER}" | grep -c '### Thanks')"
+
+echo "The parts that must always be there"
+
+check "leaves a placeholder for the summary" "1" "$(echo "${OUT}" | grep -c '^TODO:')"
+check "includes the install note" "1" "$(echo "${OUT}" | grep -c '^### Install')"
+check "links the full changelog at the repo it was run in" "1" \
+    "$(echo "${OUT}" | grep -c 'github.com/theowner/Thing/blob/master/CHANGELOG.md')"
+
+echo "Refusing to publish a draft that is still a draft"
+
+echo "${OUT}" > "${TMP}/unedited.md"
+check "--check refuses the placeholder" "1" \
+    "$( "${DRAFT}" --check "${TMP}/unedited.md" >/dev/null 2>&1; echo $? )"
+
+# What an edited one looks like: the placeholder replaced by a real summary.
+{ echo "It starts at login now."; echo; echo "${OUT}" | tail -n +4; } > "${TMP}/edited.md"
+check "--check accepts an edited draft" "0" \
+    "$( "${DRAFT}" --check "${TMP}/edited.md" >/dev/null 2>&1; echo $? )"
+
+# No summary at all is the other way to lose it: the app shows nothing above the first heading.
+echo "${OUT}" | tail -n +4 > "${TMP}/nosummary.md"
+check "--check refuses a draft with no summary" "1" \
+    "$( "${DRAFT}" --check "${TMP}/nosummary.md" >/dev/null 2>&1; echo $? )"
+
+check "--check refuses a file that isn't there" "1" \
+    "$( "${DRAFT}" --check "${TMP}/nope.md" >/dev/null 2>&1; echo $? )"
+
+echo
+if [ "${FAIL}" -eq 0 ]; then
+    echo "✓ ${PASS} passed"
+else
+    echo "✗ ${FAIL} failed, ${PASS} passed"
+    exit 1
+fi

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -291,7 +291,9 @@ swift run MacRazer poll [125|500|1000]
 swift run MacRazer rgb static ff0000 # or: spectrum | wave | off
 swift run MacRazer brightness [0-100] # sweeps LOGO/SCROLL/ZERO/BACKLIGHT LEDs
 swift run MacRazer icon out.png # render the menu bar icon
-swift run MacRazer render-ui [offline|color|update|whatsnew|…] out.png # popover (dev)
+swift run MacRazer render-ui [offline|color|update|updated|whatsnew|…] out.png # popover (dev)
+swift run MacRazer render-ui whatsnew installed out.png # the notes without an update to install
+swift run MacRazer render-about [notes] out.png
 swift run MacRazer render-remap out.png
 ```
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -291,12 +291,14 @@ swift run MacRazer poll [125|500|1000]
 swift run MacRazer rgb static ff0000 # or: spectrum | wave | off
 swift run MacRazer brightness [0-100] # sweeps LOGO/SCROLL/ZERO/BACKLIGHT LEDs
 swift run MacRazer icon out.png # render the menu bar icon
-swift run MacRazer render-ui [offline|color] out.png # render the popover (dev)
+swift run MacRazer render-ui [offline|color|update|whatsnew|…] out.png # popover (dev)
 swift run MacRazer render-remap out.png
 ```
 
-(The `render-*` commands use SwiftUI `ImageRenderer`; note it can't rasterize `ScrollView`
-or native controls, those show as placeholders.)
+(The `render-*` commands use SwiftUI `ImageRenderer`, which can't rasterize native controls —
+buttons and sliders show as placeholders. It can't rasterize a `ScrollView` either, so
+`render-ui whatsnew`, whose page *is* a scroll view, goes through an `NSHostingView` instead;
+that path draws the content but needs an explicit size, since there is no window to supply one.)
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,6 +68,7 @@
       <a href="#mice">Supported mice</a>
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="#install">Install</a>
+      <a href="releases.html">Releases</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
       <a href="https://github.com/SorcRR/MacRazer" class="topbar-gh">GitHub →</a>
     </div>
@@ -311,7 +312,7 @@
     </div>
     <div class="footer-links">
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
-      <a href="https://github.com/SorcRR/MacRazer/releases">Releases</a>
+      <a href="releases.html">Release notes</a>
       <a href="razer-synapse-alternative-mac.html">Synapse alternative</a>
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md">Changelog</a>

--- a/docs/razer-mouse-battery-mac.html
+++ b/docs/razer-mouse-battery-mac.html
@@ -77,6 +77,7 @@
       <a href="./#mice">Supported mice</a>
       <a href="razer-synapse-alternative-mac.html">Synapse alternative</a>
       <a href="./#install">Install</a>
+      <a href="releases.html">Releases</a>
       <a href="https://github.com/SorcRR/MacRazer" class="topbar-gh">GitHub →</a>
     </div>
   </nav>
@@ -222,7 +223,7 @@
       <a href="./">Home</a>
       <a href="razer-synapse-alternative-mac.html">Synapse alternative</a>
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
-      <a href="https://github.com/SorcRR/MacRazer/releases">Releases</a>
+      <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>

--- a/docs/razer-synapse-alternative-mac.html
+++ b/docs/razer-synapse-alternative-mac.html
@@ -80,6 +80,7 @@
       <a href="./#mice">Supported mice</a>
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="./#install">Install</a>
+      <a href="releases.html">Releases</a>
       <a href="https://github.com/SorcRR/MacRazer" class="topbar-gh">GitHub →</a>
     </div>
   </nav>
@@ -227,7 +228,7 @@
       <a href="./">Home</a>
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
-      <a href="https://github.com/SorcRR/MacRazer/releases">Releases</a>
+      <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -139,10 +139,17 @@
         frag.appendChild(el("code", null, m[2]));
       } else {
         var href = safeHref(m[4]);
-        var a = el("a");
-        a.appendChild(inline(m[3]));
-        if (href) { a.href = href; a.rel = "noopener"; }
-        frag.appendChild(a);
+        if (href) {
+          var a = el("a");
+          a.appendChild(inline(m[3]));
+          a.href = href;
+          a.rel = "noopener";
+          frag.appendChild(a);
+        } else {
+          // An anchor with no href still takes the accent colour and reads as a link that does
+          // nothing. Show the words instead.
+          frag.appendChild(inline(m[3]));
+        }
       }
       last = pattern.lastIndex;
     }
@@ -191,6 +198,19 @@
         continue;
       }
 
+      // Checked before the continuation below: a callout written directly under a bullet with
+      // no blank line between them would otherwise be swallowed into that bullet, marker and
+      // all, since only this branch strips the ">".
+      var quote = /^>\s?(.*)$/.exec(line);
+      if (quote) {
+        closeList();
+        closeParagraph();
+        var block = el("p", "release-callout");
+        block.appendChild(inline(quote[1]));
+        into.appendChild(block);
+        continue;
+      }
+
       // A line directly under a bullet continues it; markdown wraps, and half a sentence is
       // worse than none.
       if (list && list.lastChild) {
@@ -199,22 +219,13 @@
         continue;
       }
 
-      var quote = /^>\s?(.*)$/.exec(line);
-      var text = quote ? quote[1] : line;
-      if (quote) {
-        closeParagraph();
-        var block = el("p", "release-callout");
-        block.appendChild(inline(text));
-        into.appendChild(block);
-        continue;
-      }
       if (!paragraph) {
         paragraph = el("p", "release-text");
         into.appendChild(paragraph);
       } else {
         paragraph.appendChild(document.createTextNode(" "));
       }
-      paragraph.appendChild(inline(text));
+      paragraph.appendChild(inline(line));
     }
   }
 
@@ -254,14 +265,31 @@
   var list = document.getElementById("releases-list");
   var status = document.getElementById("releases-status");
 
+  // 100 is the API's maximum page size, and no pagination: at four releases a year that is
+  // a couple of decades. If it is ever reached, the oldest fall off the bottom silently, so
+  // paginate then rather than spending a second request on it now.
   fetch("https://api.github.com/repos/" + REPO + "/releases?per_page=100")
     .then(function (r) { return r.ok ? r.json() : null; })
     .then(function (releases) {
-      if (!releases || !releases.length) throw new Error("no releases");
+      // Filtered before the count is judged: a response holding nothing but drafts is as empty
+      // as no response, and would otherwise clear the loading line and render nothing at all.
+      var published = (releases || []).filter(function (r) { return !r.draft; });
+      if (!published.length) throw new Error("no releases");
+
+      // Built whole before anything is removed. Taking the status line out first meant a throw
+      // half-way through rendering left a page with no releases *and* no message, because the
+      // catch below writes into a node that is no longer in the document.
+      var frag = document.createDocumentFragment();
+      published.forEach(function (r) { frag.appendChild(renderRelease(r)); });
       if (status) status.remove();
-      releases
-        .filter(function (r) { return !r.draft; })
-        .forEach(function (r) { list.appendChild(renderRelease(r)); });
+      list.appendChild(frag);
+
+      // The version tag comes out of the response already in hand. Asking /releases/latest for
+      // it as well spent two of the sixty unauthenticated requests an IP gets per hour, on the
+      // one page where running out removes all the content.
+      var latest = published.filter(function (r) { return !r.prerelease; })[0] || published[0];
+      var tagEl = document.getElementById("version-tag");
+      if (tagEl && latest && latest.tag_name) tagEl.textContent = " · " + latest.tag_name;
     })
     .catch(function () {
       // Rate-limited, offline, or the API moved. Say so and point at the source rather than
@@ -275,17 +303,6 @@
       status.appendChild(a);
       status.appendChild(document.createTextNode("."));
     });
-
-  // Same best-effort version tag as every other page.
-  fetch("https://api.github.com/repos/" + REPO + "/releases/latest")
-    .then(function (r) { return r.ok ? r.json() : null; })
-    .then(function (data) {
-      var tag = data && data.tag_name;
-      if (!tag) return;
-      var inlineTag = document.getElementById("version-tag");
-      if (inlineTag) inlineTag.textContent = " · " + tag;
-    })
-    .catch(function () {});
 })();
 </script>
 </body>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Release notes | MacRazer</title>
+<meta name="description" content="Every MacRazer release and what changed in it — new mice, features and fixes for the free open-source Razer mouse app for macOS.">
+<meta name="author" content="SorcRR">
+<link rel="canonical" href="https://sorcrr.github.io/MacRazer/releases.html">
+
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://sorcrr.github.io/MacRazer/releases.html">
+<meta property="og:title" content="MacRazer release notes">
+<meta property="og:description" content="Every release and what changed in it — new mice, features and fixes.">
+<meta property="og:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="MacRazer release notes">
+<meta name="twitter:description" content="Every release and what changed in it — new mice, features and fixes.">
+<meta name="twitter:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
+
+<link rel="icon" type="image/png" href="assets/favicon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,600;1,9..144,500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="grain"></div>
+
+<header class="hero">
+  <nav class="topbar">
+    <div class="brand">
+      <a href="./" style="display:contents;color:inherit;text-decoration:none">
+        <img src="assets/icon-1024.png" alt="" class="brand-icon">
+        <span>MacRazer</span>
+      </a>
+    </div>
+    <div class="topbar-links">
+      <a href="./#features">Features</a>
+      <a href="./#mice">Supported mice</a>
+      <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
+      <a href="releases.html" aria-current="page">Releases</a>
+      <a href="https://github.com/SorcRR/MacRazer" class="topbar-gh">GitHub →</a>
+    </div>
+  </nav>
+
+  <div class="hero-content">
+    <p class="kicker">changelog · every version</p>
+    <h1>What changed,<br><em>and when</em>.</h1>
+    <p class="hero-sub">Every MacRazer release and what was in it. These are the same notes the
+    app shows you before it installs an update — install instructions left out, since you are
+    plainly already here.</p>
+    <div class="hero-actions">
+      <a href="https://github.com/SorcRR/MacRazer/releases/latest/download/MacRazer.dmg" class="btn btn-primary btn-large">
+        Download for macOS<span id="version-tag" class="version-tag"></span>
+      </a>
+      <a href="https://github.com/SorcRR/MacRazer/releases" class="btn btn-ghost">On GitHub</a>
+    </div>
+  </div>
+</header>
+
+<main>
+  <section class="releases">
+    <div id="releases-list">
+      <p class="releases-status" id="releases-status">Loading releases…</p>
+    </div>
+    <noscript>
+      <p class="releases-status">This page builds the list from the GitHub Releases API, which
+      needs JavaScript. <a href="https://github.com/SorcRR/MacRazer/releases">Read the releases
+      on GitHub</a> instead, or see
+      <a href="https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md">CHANGELOG.md</a>.</p>
+    </noscript>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-grid">
+    <div>
+      <div class="brand">
+        <img src="assets/icon-1024.png" alt="" class="brand-icon">
+        <span>MacRazer</span>
+      </div>
+      <p class="footer-disclaimer">Unofficial. Not affiliated with, authorized by, or endorsed by
+        Razer Inc. Protocol ported from <a href="https://github.com/openrazer/openrazer">OpenRazer</a>.</p>
+    </div>
+    <div class="footer-links">
+      <a href="./">Home</a>
+      <a href="razer-synapse-alternative-mac.html">Synapse alternative</a>
+      <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
+      <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
+      <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
+      <a href="https://ko-fi.com/sorcrr">Tips</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+
+  // Release bodies are markdown written by hand, and they end up in this page as *text* —
+  // every string below goes through textContent or a created element, never innerHTML. A
+  // release note is not a place to start trusting markup.
+  var REPO = "SorcRR/MacRazer";
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  // Only http(s). A link is the one thing here that becomes an attribute rather than text,
+  // so it is the one thing that has to be checked.
+  function safeHref(url) {
+    return /^https?:\/\//i.test(url) ? url : null;
+  }
+
+  /* ---------- the small markdown subset release bodies actually use ---------- */
+
+  // **bold**, `code`, [text](url) — tokenised into nodes rather than substituted into a
+  // string, so nothing in the text can turn into markup.
+  function inline(text) {
+    var frag = document.createDocumentFragment();
+    var pattern = /\*\*([^*]+)\*\*|`([^`]+)`|\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+    var last = 0;
+    var m;
+    while ((m = pattern.exec(text)) !== null) {
+      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
+      if (m[1] != null) {
+        // Recursed, because the emphasis nests: these notes routinely write
+        // **`VersionCompare` no longer misorders releases**, and taking the bold run as plain
+        // text left the backticks on the page. It terminates — each level strips its own
+        // delimiters, so the inner string is always shorter.
+        var strong = el("strong");
+        strong.appendChild(inline(m[1]));
+        frag.appendChild(strong);
+      } else if (m[2] != null) {
+        frag.appendChild(el("code", null, m[2]));
+      } else {
+        var href = safeHref(m[4]);
+        var a = el("a");
+        a.appendChild(inline(m[3]));
+        if (href) { a.href = href; a.rel = "noopener"; }
+        frag.appendChild(a);
+      }
+      last = pattern.lastIndex;
+    }
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    return frag;
+  }
+
+  // Sections the reader of *this* page has no use for. Same rule the app applies to the same
+  // bodies: by the time these notes are in front of you, you have managed the install.
+  var DROPPED = { "install": 1, "installation": 1, "download": 1 };
+
+  function renderBody(markdown, into) {
+    var lines = String(markdown || "").split(/\r?\n/);
+    var list = null;          // open <ul>, if any
+    var paragraph = null;     // open <p>, for wrapped prose
+    var dropping = false;     // inside a section we are not showing
+
+    function closeList() { list = null; }
+    function closeParagraph() { paragraph = null; }
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim();
+
+      // The changelog footer is a link back to where the reader already is.
+      if (/^\*\*full changelog:/i.test(line)) break;
+
+      if (line === "") { closeList(); closeParagraph(); continue; }
+
+      var heading = /^#{1,6}\s+(.*)$/.exec(line);
+      if (heading) {
+        closeList(); closeParagraph();
+        var title = heading[1].replace(/\*\*/g, "").trim();
+        dropping = Object.prototype.hasOwnProperty.call(DROPPED, title.toLowerCase());
+        if (!dropping) into.appendChild(el("h3", "release-section", title));
+        continue;
+      }
+      if (dropping) continue;
+
+      var bullet = /^[-*+]\s+(.*)$/.exec(line);
+      if (bullet) {
+        closeParagraph();
+        if (!list) { list = el("ul", "release-items"); into.appendChild(list); }
+        var li = el("li");
+        li.appendChild(inline(bullet[1]));
+        list.appendChild(li);
+        continue;
+      }
+
+      // A line directly under a bullet continues it; markdown wraps, and half a sentence is
+      // worse than none.
+      if (list && list.lastChild) {
+        list.lastChild.appendChild(document.createTextNode(" "));
+        list.lastChild.appendChild(inline(line));
+        continue;
+      }
+
+      var quote = /^>\s?(.*)$/.exec(line);
+      var text = quote ? quote[1] : line;
+      if (quote) {
+        closeParagraph();
+        var block = el("p", "release-callout");
+        block.appendChild(inline(text));
+        into.appendChild(block);
+        continue;
+      }
+      if (!paragraph) {
+        paragraph = el("p", "release-text");
+        into.appendChild(paragraph);
+      } else {
+        paragraph.appendChild(document.createTextNode(" "));
+      }
+      paragraph.appendChild(inline(text));
+    }
+  }
+
+  function renderRelease(release) {
+    var article = el("article", "release");
+
+    var head = el("div", "release-head");
+    var tag = release.tag_name || "";
+    var h2 = el("h2", "release-version");
+    var link = el("a", null, tag);
+    var href = safeHref(release.html_url || "");
+    if (href) { link.href = href; link.rel = "noopener"; }
+    h2.appendChild(link);
+    head.appendChild(h2);
+
+    var meta = el("div", "release-meta");
+    if (release.published_at) {
+      var when = new Date(release.published_at);
+      var time = el("time", null, when.toLocaleDateString(undefined,
+        { year: "numeric", month: "long", day: "numeric" }));
+      time.dateTime = release.published_at;
+      meta.appendChild(time);
+    }
+    if (release.prerelease) meta.appendChild(el("span", "release-badge", "pre-release"));
+    head.appendChild(meta);
+    article.appendChild(head);
+
+    var body = el("div", "release-body");
+    renderBody(release.body, body);
+    if (!body.firstChild) {
+      body.appendChild(el("p", "release-text", "No notes were published for this release."));
+    }
+    article.appendChild(body);
+    return article;
+  }
+
+  var list = document.getElementById("releases-list");
+  var status = document.getElementById("releases-status");
+
+  fetch("https://api.github.com/repos/" + REPO + "/releases?per_page=100")
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (releases) {
+      if (!releases || !releases.length) throw new Error("no releases");
+      if (status) status.remove();
+      releases
+        .filter(function (r) { return !r.draft; })
+        .forEach(function (r) { list.appendChild(renderRelease(r)); });
+    })
+    .catch(function () {
+      // Rate-limited, offline, or the API moved. Say so and point at the source rather than
+      // leaving a page that just says "Loading…" forever.
+      if (!status) return;
+      status.textContent = "";
+      status.appendChild(document.createTextNode("Couldn't load the releases just now. "));
+      var a = el("a", null, "Read them on GitHub");
+      a.href = "https://github.com/" + REPO + "/releases";
+      a.rel = "noopener";
+      status.appendChild(a);
+      status.appendChild(document.createTextNode("."));
+    });
+
+  // Same best-effort version tag as every other page.
+  fetch("https://api.github.com/repos/" + REPO + "/releases/latest")
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      var tag = data && data.tag_name;
+      if (!tag) return;
+      var inlineTag = document.getElementById("version-tag");
+      if (inlineTag) inlineTag.textContent = " · " + tag;
+    })
+    .catch(function () {});
+})();
+</script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -15,4 +15,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://sorcrr.github.io/MacRazer/releases.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/docs/style.css
+++ b/docs/style.css
@@ -521,3 +521,83 @@ tbody tr:hover { background: var(--bg-raised); }
   .topbar-links a:not(.topbar-gh) { display: none; }
   h1 { font-size: 38px; }
 }
+
+/* ---------- release notes ---------- */
+.releases {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 72px 24px 96px;
+}
+
+.releases-status { color: var(--text-dim); font-size: 14px; }
+.releases-status a { color: var(--accent); }
+
+.release {
+  border-top: 1px solid var(--border-soft);
+  padding: 34px 0 6px;
+}
+.release:first-child { border-top: 0; padding-top: 8px; }
+
+.release-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.release-version { font-size: 26px; }
+.release-version a:hover { color: var(--accent); }
+
+.release-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+
+.release-badge {
+  background: rgba(224, 166, 79, 0.1);
+  color: var(--amber);
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 11px;
+}
+
+.release-body { color: var(--text-dim); font-size: 14px; }
+.release-body a { color: var(--accent); }
+.release-body code {
+  background: var(--bg-raised-2);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 12.5px;
+}
+.release-body strong { color: var(--text); font-weight: 500; }
+
+.release-section {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 26px 0 10px;
+}
+
+.release-text { margin: 0 0 14px; }
+
+.release-callout {
+  margin: 0 0 18px;
+  padding: 12px 16px;
+  border-left: 2px solid var(--accent-dim);
+  background: var(--bg-raised);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.release-items { margin: 0 0 14px; padding-left: 20px; }
+.release-items li { margin-bottom: 9px; }
+
+@media (max-width: 640px) {
+  .releases { padding: 48px 18px 64px; }
+  .release-version { font-size: 22px; }
+}


### PR DESCRIPTION
The update card said a version was available and nothing about what was in it. That's asking someone to replace their app on no information — the thing the macOS convention of showing release notes in the update dialog exists to prevent.

The data was already there. `UpdateChecker` calls `releases/latest` and decodes `tag_name` out of a response that also carries `body`. One more `Decodable` field.

## Why a page and not the card

With an update showing, the popover is already **748pt** tall, against roughly 600–700pt of usable height for a menu bar popover on a laptop. Inline notes would have added another 150–200pt.

| | height |
|---|---|
| popover today, update card showing | 748pt |
| with the "What's new" row | 770pt (+22) |
| the notes page itself | 748pt, scrolls if a release is chatty |

So the card gains **one row** — `What's new in 0.3.1 ›`, the same chevron row as *Configure Buttons…* below it — and the notes get the whole popover, using the navigation already there for Buttons, Usage, Profiles and Colour. *Update & Restart* is repeated at the bottom of the page, so the decision can be made where the information is.

## The parser

`ReleaseNotes` is pure — no network, no UI — because its input is prose written by hand months apart, so every shape it can arrive in should be replayable in a test. The 15 tests run against the **real 0.3.0 body verbatim**, plus the shapes a future body plausibly takes:

- `###` and `##` headings (ours vs. GitHub's *Generate release notes*)
- `-`, `*` and `+` bullets
- a bullet list with no headings at all
- a bullet wrapped across two lines
- bold lead, quoted feature name, mid-sentence bold, no emphasis at all
- an overlong "headline" that's really just the sentence in bold, left whole

`### Install` and the `**Full changelog:` footer are dropped — by the time these are on screen the reader has plainly managed the install. Anything the parser can't classify still reaches the reader as plain text; `testNothingIsEverSilentlyLost` asserts it.

## Rendering

`render-ui whatsnew` renders the page against the real 0.3.0 body. It goes through `NSHostingView` rather than `ImageRenderer`, which draws a `ScrollView` as an empty box — that's how the first render of this page came out blank. While in there, `render-ui update` used to write a file literally named `update`; same positional-path bug `icon` was already fixed for.

## Releases now come with a body, and it credits people

The body stopped being cosmetic the moment the app started reading it, so the other half is here too. `release.sh` drafts `dist/RELEASE_NOTES-<version>.md` after it closes off the changelog, and prints `--notes-file` instead of `--notes-from-tag`.

It drafts the **mechanical** half only — entries come out verbatim, because a script that paraphrased them would be inventing copy nobody reviewed. What it fills in is what gets forgotten:

- every entry in the release
- **everyone whose PR is in it** — handle, PR title and number, read straight out of the merge commits (no network, no token). The maintainer's own merges are excluded, matched against the owner read from the remote rather than hardcoded.
- the Gatekeeper install note and the changelog link

A squash-merged PR leaves no merge commit to read, so its author can't be credited automatically — reported on stderr to add by hand, rather than silently dropped.

`--check` refuses a draft still carrying its `TODO:` placeholder or with nothing above its first heading; either would become the release's first paragraph, which is exactly what the app shows as the summary.

Run against the real history, it produces:

```
### Thanks
- **@joelday** — Add Razer Basilisk V3 X HyperSpeed (0x00B9) and Basilisk X HyperSpeed (0x0083) (#5)
- **@raphaelchenouard** — Add Razer Orochi 2013 and Viper Ultimate (#6)
```

19 fixture tests in `Tests/Scripts/release-notes-test.sh`, running against a real throwaway repository with real merge commits, wired into CI.

## Two things the tests found rather than confirmed

- `git merge -m` with an embedded newline folds into a single subject line. The fixture built that way had no PR title to read — which surfaced the real case it stood for: a hand-made merge with no body now omits the dash instead of printing `@user —  (#5)`.
- A Swift test asserting the shell script's output shape parses as intended caught `— Add support for the thing` arriving as the detail text. `trimLead` now drops dashes, and `**Name** — what it does` is the shape our own notes use most.

## The notes outlive the update

They had one entry point — the update card — which exists only while a newer version is on offer. Install it and the card goes, and the notes go with it. With **Install updates automatically** on, the card was never there to begin with: that setting could take someone from 0.3.0 to 0.3.2 without a word about any of it, which is the gap the feature was meant to close.

Nothing needs fetching. Every successful check already caches the latest release's version and body together, and after an install that release is the one running — so the same cache answers "what changed?" afterwards. It answers for a hand-installed DMG too, from the first check after.

Two places, for two different needs:

| | where | when |
|---|---|---|
| **"Updated to 0.3.1"** card, dismissible, with the same What's new row | popover | first launch on a new version |
| **"What's new in 0.3.1"** under the version number | About window | any time after |

The page opened from either of those has no install button — there is nothing left to install.

`UpdateAnnouncement` is the pure part, and its cases are the ones awkward to reach by hand: **a first install is not an update** ("Updated to 0.3.1" on a first launch is simply false), the same version twice is not, dismissing is per-version so the next release still speaks up, and a downgrade is a change worth announcing. The version is recorded at launch rather than at quit — an app replaced under itself and relaunched never gets a clean shutdown, and the only thing worse than a missed announcement is the same one every launch.

Which cached body may answer for the running version is pure too, because the cache tracks the newest release *seen*, not what is installed: someone who skipped 0.3.2 would otherwise read its notes in an About box that says 0.3.1.

## A release notes page on the site

`docs/releases.html`, linked from the nav on every page and from the footer — the footer because the topbar hides all but the GitHub link below 640px, so it is the only nav a phone keeps. Every version and what was in it, built from the same release bodies the app shows and `release-notes.sh` drafts. Install sections and the "Full changelog" footer are dropped by the same rule the app applies.

It reads the API at page load rather than being generated at release time, so a release reaches the site without the site being touched. The cost is that the content needs JavaScript: there is a `<noscript>` pointing at GitHub and CHANGELOG.md, and a rate-limited or unreachable API leaves a message and a link rather than "Loading…" forever. Static generation is the alternative if the SEO matters more than the upkeep.

All release text becomes DOM nodes via `textContent`, never HTML strings; the one value that becomes an attribute, a link `href`, is checked for http(s) first.

Rendering it against the real releases caught something reading would not have: the notes routinely write \*\*\`VersionCompare\` no longer misorders releases\*\* — emphasis around a code span — and taking the bold run as plain text left literal backticks on the page. Inline formatting recurses now.

## Verification

- 134 Swift tests, 35 release-notes fixture tests, 20 release-script tests
- `render-ui update`, `render-ui updated`, `render-ui whatsnew installed` and `render-about notes` all inspected against the real release body; the notes fit the page with ~150pt to spare
- `./Tests/Scripts/changelog-test.sh` passes
- the site page checked in a browser against the live API: 9 releases render, no console errors, no stray markdown, no horizontal overflow at 375px



