### PR TITLE
Link Hiveship from the About window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,18 @@ expect rough edges until 1.0.
  you open daily to read a battery percentage, and nothing permanent there stays subtle past
  the third time you see it.
 
-- **The About window reads like a person wrote it.** The copy had picked up the house style of
- an AI: em dashes everywhere, clauses stacked three deep, semicolons joining sentences that
- wanted to be two. Same facts, same trademark and licence wording, shorter sentences.
+- **The app and the site read like a person wrote them.** The copy had picked up the house
+ style of an AI: em dashes everywhere, clauses stacked three deep, semicolons joining
+ sentences that wanted to be two. Swept through every string a user sees, in the popover,
+ Settings, permissions, profiles, remapping, the low-battery notification and the update
+ errors, and through the prose on all four site pages. Same facts throughout, including the
+ trademark and licence wording, just shorter sentences. `release-notes.sh --check` now
+ refuses a draft containing an em dash, so release bodies stay that way without anyone having
+ to remember. Contributor-facing text is left alone: code comments, CLI diagnostics and the
+ page titles search engines have already indexed.
+
+- **A "Built with Hiveship" link in the README and in the site footer**, alongside the one in
+ the About window.
 
 - **The About preview renders real buttons.** `render-about` went through `ImageRenderer`,
  which draws every native control as a placeholder — and that window is mostly buttons and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,11 +69,17 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
-- **An "Also from SorcRR" line in the About window**, pointing at Hiveship. Labelled as the
- developer's own product rather than dressed up as a recommendation: every other link in that
- window credits someone, and a commercial one borrowing that tone would be trading on it. In
+- **A "For developers" section in the About window**, with a Go to Hiveship button. It says
+ what Hiveship is and stops there: it does not claim MacRazer's own planning or bug tracking
+ happens in it, because that board is not public and a reader clicking on the strength of
+ "tracked here" would land on a signup page rather than the thing they were promised. In
  About and not the popover — the popover is opened daily to read a battery percentage, and
  nothing permanent there stays subtle past the third time you see it.
+
+- **The About preview renders real buttons.** `render-about` went through `ImageRenderer`,
+ which draws every native control as a placeholder — and that window is mostly buttons and
+ links, so the preview could not show the one thing it exists to check. It uses the hosted
+ path now, sized from the view's own `fittingSize`.
 - **The "What's new" summary survives a line wrap.** Every source line above the first
  heading became its own paragraph, so a summary hard-wrapped across two lines — the house
  style in every markdown file here, and what the drafted template itself does — showed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ expect rough edges until 1.0.
  so plainly, with a note that an unverified mouse is not a broken one.
 
 ### Fixed
+- **The site footer links wrap instead of running off the side of a phone.** `.footer-links`
+ was a flex row with no `flex-wrap`, so on a 375px screen the last two links were simply cut
+ off at the edge. Long-standing, and easy to miss on a desktop browser.
 - **The changelog can no longer accumulate duplicate headings unnoticed.** Two branches each
  adding a `### Fixed` under `[Unreleased]` merge cleanly — git appends, nothing conflicts, and
  nobody spots it in a diff. It happened three times across one stack, and then again in the PR
@@ -84,8 +87,10 @@ expect rough edges until 1.0.
  to remember. Contributor-facing text is left alone: code comments, CLI diagnostics and the
  page titles search engines have already indexed.
 
-- **A "Built with Hiveship" link in the README and in the site footer**, alongside the one in
- the About window.
+- **A "Built with Hiveship" card in the site footer**, with the Hiveship mark, on all four
+ pages, plus a line in the README alongside the one in the About window. The mark is a 901
+ byte SVG copied into `docs/assets/` rather than hotlinked, so the site stays self-contained
+ and doesn't reach out to another origin on every page load.
 
 - **The About preview renders real buttons.** `render-about` went through `ImageRenderer`,
  which draws every native control as a placeholder — and that window is mostly buttons and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ expect rough edges until 1.0.
 - **The site footer links wrap instead of running off the side of a phone.** `.footer-links`
  was a flex row with no `flex-wrap`, so on a 375px screen the last two links were simply cut
  off at the edge. Long-standing, and easy to miss on a desktop browser.
+
+- **The footer no longer ends flush against its last element.** The space under it was a
+ bottom margin on the last child, and the footer has no bottom padding or border of its own,
+ so that margin collapsed straight out and the background stopped dead at the element. It is
+ padding on the footer now, where it cannot collapse.
 - **The changelog can no longer accumulate duplicate headings unnoticed.** Two branches each
  adding a `### Fixed` under `[Unreleased]` merge cleanly — git appends, nothing conflicts, and
  nobody spots it in a diff. It happened three times across one stack, and then again in the PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
+- **An "Also from SorcRR" line in the About window**, pointing at Hiveship. Labelled as the
+ developer's own product rather than dressed up as a recommendation: every other link in that
+ window credits someone, and a commercial one borrowing that tone would be trading on it. In
+ About and not the popover — the popover is opened daily to read a battery percentage, and
+ nothing permanent there stays subtle past the third time you see it.
 - **The "What's new" summary survives a line wrap.** Every source line above the first
  heading became its own paragraph, so a summary hard-wrapped across two lines — the house
  style in every markdown file here, and what the drafted template itself does — showed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,14 @@ expect rough edges until 1.0.
  BACKLIGHT individually, so a new model's brightness LED can be found in one run.
 
 ### Added
-- **A "For developers" section in the About window**, with a Go to Hiveship button. It says
- what Hiveship is and stops there: it does not claim MacRazer's own planning or bug tracking
- happens in it, because that board is not public and a reader clicking on the strength of
- "tracked here" would land on a signup page rather than the thing they were promised. In
- About and not the popover — the popover is opened daily to read a battery percentage, and
- nothing permanent there stays subtle past the third time you see it.
+- **A "For developers" section in the About window**, saying MacRazer was built with
+ Hiveship, with a button to go there. In About rather than the popover: the popover is what
+ you open daily to read a battery percentage, and nothing permanent there stays subtle past
+ the third time you see it.
+
+- **The About window reads like a person wrote it.** The copy had picked up the house style of
+ an AI: em dashes everywhere, clauses stacked three deep, semicolons joining sentences that
+ wanted to be two. Same facts, same trademark and licence wording, shorter sentences.
 
 - **The About preview renders real buttons.** `render-about` went through `ImageRenderer`,
  which draws every native control as a placeholder — and that window is mostly buttons and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,9 @@ expect rough edges until 1.0.
  sentences that wanted to be two. Swept through every string a user sees, in the popover,
  Settings, permissions, profiles, remapping, the low-battery notification and the update
  errors, and through the prose on all four site pages. Same facts throughout, including the
- trademark and licence wording, just shorter sentences. `release-notes.sh --check` now
+ trademark and licence wording, which are left exactly as they were: "used here only to
+ describe compatibility" is the conventional descriptive-use formulation and the reason this
+ app may show Razer's marks at all. `release-notes.sh --check` now
  refuses a draft containing an em dash, so release bodies stay that way without anyone having
  to remember. Contributor-facing text is left alone: code comments, CLI diagnostics and the
  page titles search engines have already indexed.

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ are in [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md). The complete feature hist
 
 ## Built with
 
-MacRazer is planned and tracked in [Hiveship](https://hiveship.app/), an issue tracker for
-handing work to coding agents as well as the people on your team.
+MacRazer was built with [Hiveship](https://hiveship.app/), an issue tracker for planning work,
+tracking bugs, and handing issues to coding agents as well as the people on your team.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Full details, including the protocol, the per-device hardware quirks, and a file
 are in [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md). The complete feature history is in
 [CHANGELOG.md](CHANGELOG.md).
 
+## Built with
+
+MacRazer is planned and tracked in [Hiveship](https://hiveship.app/), an issue tracker for
+handing work to coding agents as well as the people on your team.
+
 ## Contributing
 
 Pull requests are welcome, especially **device profiles** so this works on more Razer mice.

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -51,13 +51,19 @@ note() { echo "  $*" >&2; }
 if [ -n "${CHECK}" ]; then
     [ -f "${CHECK}" ] || fail "no such file: ${CHECK}"
     if grep -q '^TODO:' "${CHECK}"; then
-        fail "${CHECK} still has the TODO placeholder — that would be the release's first paragraph"
+        fail "${CHECK} still has the TODO placeholder. That would be the release's first paragraph."
     fi
     # `/^#/`, not an interval expression: not every awk supports `{1,6}`, and in markdown
     # nothing but a heading starts a line with a hash anyway.
     SUMMARY="$(awk '/^#/{exit} {print}' "${CHECK}" | tr -d '[:space:]')"
     [ -n "${SUMMARY}" ] \
-        || fail "${CHECK} has nothing above its first heading — the app would show no summary"
+        || fail "${CHECK} has nothing above its first heading, so the app would show no summary"
+    # Em dashes read as machine-written, and this text is published three times over: the
+    # releases page, the site, and the app's own What's New. A full stop or a colon almost
+    # always says the same thing.
+    if grep -n '—' "${CHECK}" >&2; then
+        fail "${CHECK} has em dashes on the lines above. Use a full stop, a colon or a comma."
+    fi
     echo "✓ ${CHECK} looks publishable" >&2
     exit 0
 fi
@@ -127,9 +133,9 @@ for sha in ${MERGES}; do
             # maintainer in their own release notes.
             [ "$(echo "${handle}" | tr 'A-Z' 'a-z')" = "$(echo "${OWNER}" | tr 'A-Z' 'a-z')" ] && continue
             title="$(git log -1 --format='%b' "${sha}" | head -1)"
-            # A merge made by hand can carry no body, and "@caseyc —  (#5)" reads as a typo.
+            # A merge made by hand can carry no body, and "@caseyc:  (#5)" reads as a typo.
             if [ -n "${title}" ]; then
-                THANKS="${THANKS}- **@${handle}** — ${title} (#${pr})
+                THANKS="${THANKS}- **@${handle}**: ${title} (#${pr})
 "
             else
                 THANKS="${THANKS}- **@${handle}** (#${pr})
@@ -169,7 +175,7 @@ done | sort -u)"
 # --- The draft -------------------------------------------------------------------------------
 
 cat <<EOF
-TODO: one line saying what this release is about — the app shows everything above the first
+TODO: one line saying what this release is about. The app shows everything above the first
 heading as the summary. The entries below are verbatim from the changelog, which is written
 for contributors: tighten them for users, expect to cut most of it, and delete these lines.
 EOF

--- a/Scripts/release-notes.sh
+++ b/Scripts/release-notes.sh
@@ -220,6 +220,17 @@ if [ -n "${MALFORMED}" ]; then
         note "    ${m}"
     done
 fi
+# The entries come out of the changelog verbatim, and the changelog is written for
+# contributors, where an em dash is nobody's problem. The published body is held to a
+# different standard by --check, so say so here, while the draft is being edited, rather than
+# letting the gate reject lines the script itself just copied. The section is the only part
+# that can carry one: everything else in the draft is written below.
+EM_DASH_LINES="$(echo "${SECTION}" | grep -c '—' || true)"
+if [ "${EM_DASH_LINES}" -gt 0 ] 2>/dev/null; then
+    note ""
+    note "⚠ ${EM_DASH_LINES} line(s) carry an em dash, copied from the changelog. --check will"
+    note "  reject them. A full stop or a colon almost always says the same thing."
+fi
 if [ -n "${UNCREDITED}" ]; then
     note ""
     note "⚠ These authors wrote commits in the range but have no merge commit to credit them by"

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -79,9 +79,12 @@ struct AboutView: View {
         titledSection("Unofficial") {
             sectionNote("An independent community project. Not affiliated with, authorized by, "
                         + "or endorsed by Razer Inc.")
+            // "Used here only to describe compatibility" is the conventional descriptive-use
+            // wording and the reason this app may put Razer's marks on screen at all, so it
+            // stays as written. Only the semicolon became a full stop.
             sectionNote("“Razer”, “Cobra”, “HyperSpeed”, “Synapse” and “Chroma” are trademarks of "
-                        + "Razer Inc. They are used here only to say which mice this works with. "
-                        + "The mouse icon is the app's own drawing, not Razer's logo.")
+                        + "Razer Inc., used here only to describe compatibility. The app's mouse "
+                        + "mark is its own. It does not display Razer's logo.")
         }
     }
 
@@ -103,7 +106,8 @@ struct AboutView: View {
 
     private var licenseSection: some View {
         titledSection("License") {
-            sectionNote("GPL-2.0-or-later. It has to be GPL, because it builds on OpenRazer.")
+            sectionNote("GPL-2.0-or-later. It has to be GPL, because it builds on OpenRazer, "
+                        + "which is GPL.")
             sectionNote("Provided as is, with no warranty of any kind. It talks to your mouse over "
                         + "HID and only sends the same feature reports OpenRazer and Synapse do, "
                         + "but you run it at your own risk.")
@@ -151,7 +155,7 @@ struct AboutView: View {
             sectionNote("MacRazer was built with Hiveship. It's an issue tracker for planning "
                         + "work, tracking bugs, and handing issues to coding agents as well as "
                         + "the people on your team.")
-            Link(destination: ProjectLinks.hiveship) {
+            Link(destination: ElsewhereLinks.hiveship) {
                 Label("Go to Hiveship", systemImage: "arrow.up.right")
             }
             .buttonStyle(.bordered)

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -27,6 +27,7 @@ struct AboutView: View {
             unofficialSection
             openRazerSection
             licenseSection
+            alsoFromSection
             footer
         }
         .padding(22)
@@ -130,6 +131,25 @@ struct AboutView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: Also from the developer
+
+    /// The one piece of this window that is not about MacRazer.
+    ///
+    /// Labelled as the developer's own product rather than dressed up as a recommendation:
+    /// every other link here credits someone, and a commercial link that borrowed that tone
+    /// would be trading on it. Below the licence, in About rather than the popover — the
+    /// popover is opened daily to read a battery percentage, and nothing permanent there stays
+    /// subtle past the third time you see it.
+    private var alsoFromSection: some View {
+        titledSection("Also from SorcRR") {
+            sectionNote("Hiveship — an issue tracker for teams handing work to coding agents "
+                        + "alongside the people doing it. Nothing to do with mice.")
+            Link("hiveship.app", destination: ProjectLinks.hiveship)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(Color.razerGreen)
         }
     }
 

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -77,21 +77,21 @@ struct AboutView: View {
 
     private var unofficialSection: some View {
         titledSection("Unofficial") {
-            sectionNote("An independent community project. It is not affiliated with, authorized by, "
+            sectionNote("An independent community project. Not affiliated with, authorized by, "
                         + "or endorsed by Razer Inc.")
             sectionNote("“Razer”, “Cobra”, “HyperSpeed”, “Synapse” and “Chroma” are trademarks of "
-                        + "Razer Inc., used here only to describe compatibility. The app's mouse mark "
-                        + "is its own; it does not display Razer's logo.")
+                        + "Razer Inc. They are used here only to say which mice this works with. "
+                        + "The mouse icon is the app's own drawing, not Razer's logo.")
         }
     }
 
     private var openRazerSection: some View {
         titledSection("Built on OpenRazer") {
-            sectionNote("The device protocol — command bytes, the report structure, CRC, the Cobra "
-                        + "command set — was ported from OpenRazer's Linux driver. The hard "
-                        + "reverse-engineering is theirs.")
-            sectionNote("Cobra HyperSpeed support follows OpenRazer PR #2583 by dyharlan, reviewed "
-                        + "by z3ntu, which established that the device reuses the Cobra Pro protocol.")
+            sectionNote("Everything this app says to your mouse was ported from OpenRazer's Linux "
+                        + "driver: the command bytes, the report structure, the CRC, the Cobra "
+                        + "command set. They did the hard reverse engineering.")
+            sectionNote("Cobra HyperSpeed support follows their PR #2583 by dyharlan, reviewed by "
+                        + "z3ntu, which worked out that the mouse reuses the Cobra Pro protocol.")
             HStack(spacing: 14) {
                 Link("OpenRazer", destination: ProjectLinks.openRazer)
                 Link("PR #2583", destination: ProjectLinks.cobraHyperSpeedPR)
@@ -103,10 +103,10 @@ struct AboutView: View {
 
     private var licenseSection: some View {
         titledSection("License") {
-            sectionNote("GPL-2.0-or-later — GPL because it derives from OpenRazer, which is GPL.")
-            sectionNote("Provided as is, without warranty of any kind. It talks to your mouse over "
-                        + "HID; it only sends the same feature reports OpenRazer and Synapse use, but "
-                        + "you run it at your own risk.")
+            sectionNote("GPL-2.0-or-later. It has to be GPL, because it builds on OpenRazer.")
+            sectionNote("Provided as is, with no warranty of any kind. It talks to your mouse over "
+                        + "HID and only sends the same feature reports OpenRazer and Synapse do, "
+                        + "but you run it at your own risk.")
             Link("View the source", destination: ProjectLinks.repo)
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(Color.razerGreen)
@@ -148,8 +148,9 @@ struct AboutView: View {
     /// percentage, and nothing permanent there stays subtle past the third time you see it.
     private var hiveshipSection: some View {
         titledSection("For developers") {
-            sectionNote("Hiveship — plan work, track bugs, and hand issues to coding agents "
-                        + "alongside the people doing them.")
+            sectionNote("MacRazer was built with Hiveship. It's an issue tracker for planning "
+                        + "work, tracking bugs, and handing issues to coding agents as well as "
+                        + "the people on your team.")
             Link(destination: ProjectLinks.hiveship) {
                 Label("Go to Hiveship", systemImage: "arrow.up.right")
             }

--- a/Sources/MacRazer/AboutView.swift
+++ b/Sources/MacRazer/AboutView.swift
@@ -27,7 +27,7 @@ struct AboutView: View {
             unofficialSection
             openRazerSection
             licenseSection
-            alsoFromSection
+            hiveshipSection
             footer
         }
         .padding(22)
@@ -134,22 +134,27 @@ struct AboutView: View {
         }
     }
 
-    // MARK: Also from the developer
+    // MARK: For developers
 
     /// The one piece of this window that is not about MacRazer.
     ///
-    /// Labelled as the developer's own product rather than dressed up as a recommendation:
-    /// every other link here credits someone, and a commercial link that borrowed that tone
-    /// would be trading on it. Below the licence, in About rather than the popover — the
-    /// popover is opened daily to read a battery percentage, and nothing permanent there stays
-    /// subtle past the third time you see it.
-    private var alsoFromSection: some View {
-        titledSection("Also from SorcRR") {
-            sectionNote("Hiveship — an issue tracker for teams handing work to coding agents "
-                        + "alongside the people doing it. Nothing to do with mice.")
-            Link("hiveship.app", destination: ProjectLinks.hiveship)
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundStyle(Color.razerGreen)
+    /// It describes what Hiveship is and stops there. It does not say MacRazer's own work is
+    /// planned or tracked in it — that board is not public, so a reader who clicked on the
+    /// strength of "tracked here" would land on a signup page instead of the thing they were
+    /// promised. Saying what the product does and offering a button asks for the same click
+    /// without setting up that gap.
+    ///
+    /// In About rather than the popover: the popover is opened daily to read a battery
+    /// percentage, and nothing permanent there stays subtle past the third time you see it.
+    private var hiveshipSection: some View {
+        titledSection("For developers") {
+            sectionNote("Hiveship — plan work, track bugs, and hand issues to coding agents "
+                        + "alongside the people doing them.")
+            Link(destination: ProjectLinks.hiveship) {
+                Label("Go to Hiveship", systemImage: "arrow.up.right")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
     }
 

--- a/Sources/MacRazer/AppDelegate.swift
+++ b/Sources/MacRazer/AppDelegate.swift
@@ -309,7 +309,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, UNU
         guard controller.connected, let pct = controller.batteryPercent else {
             return name
         }
-        return "\(name) — \(pct)%" + (controller.charging ? " (charging)" : "")
+        return "\(name) · \(pct)%" + (controller.charging ? " (charging)" : "")
     }
 
     @objc private func refreshNow() { controller.refreshAll() }

--- a/Sources/MacRazer/AppInfo.swift
+++ b/Sources/MacRazer/AppInfo.swift
@@ -47,6 +47,11 @@ enum ProjectLinks {
     static let latestReleaseAPI =
         URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
 
+    /// The developer's other project, linked from About. Not part of MacRazer — kept here
+    /// because this is where the project's URLs live, and one scattered link is how a dead one
+    /// survives a rename.
+    static let hiveship = URL(string: "https://hiveship.app/")!
+
     // Upstream, credited in the About window and NOTICE.md.
     static let openRazer = URL(string: "https://github.com/openrazer/openrazer")!
     static let cobraHyperSpeedPR = URL(string: "https://github.com/openrazer/openrazer/pull/2583")!

--- a/Sources/MacRazer/AppInfo.swift
+++ b/Sources/MacRazer/AppInfo.swift
@@ -31,6 +31,13 @@ enum AppInfo {
 /// four files, so a rename would have left the updater polling one place while the About
 /// window linked to another — and nothing would have failed loudly, the update card would
 /// just have quietly stopped finding releases.
+/// Somewhere else entirely. `ProjectLinks` is every URL that identifies *this* project, and
+/// putting an unrelated one in there would make that sentence false for whoever adds the next.
+enum ElsewhereLinks {
+    /// The About window's "For developers" section.
+    static let hiveship = URL(string: "https://hiveship.app/")!
+}
+
 enum ProjectLinks {
     static let repo = URL(string: "https://github.com/SorcRR/MacRazer")!
     static let site = URL(string: "https://sorcrr.github.io/MacRazer/")!
@@ -46,11 +53,6 @@ enum ProjectLinks {
     static let latestDMG = repo.appendingPathComponent("releases/latest/download/MacRazer.dmg")
     static let latestReleaseAPI =
         URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
-
-    /// Linked from the About window. Not part of MacRazer — kept here because this is where
-    /// the project's URLs live, and one link scattered somewhere else is how a dead one
-    /// survives a rename.
-    static let hiveship = URL(string: "https://hiveship.app/")!
 
     // Upstream, credited in the About window and NOTICE.md.
     static let openRazer = URL(string: "https://github.com/openrazer/openrazer")!

--- a/Sources/MacRazer/AppInfo.swift
+++ b/Sources/MacRazer/AppInfo.swift
@@ -47,8 +47,8 @@ enum ProjectLinks {
     static let latestReleaseAPI =
         URL(string: "https://api.github.com/repos/SorcRR/MacRazer/releases/latest")!
 
-    /// The developer's other project, linked from About. Not part of MacRazer — kept here
-    /// because this is where the project's URLs live, and one scattered link is how a dead one
+    /// Linked from the About window. Not part of MacRazer — kept here because this is where
+    /// the project's URLs live, and one link scattered somewhere else is how a dead one
     /// survives a rename.
     static let hiveship = URL(string: "https://hiveship.app/")!
 

--- a/Sources/MacRazer/LaunchAtLogin.swift
+++ b/Sources/MacRazer/LaunchAtLogin.swift
@@ -75,8 +75,8 @@ final class LaunchAtLogin: ObservableObject {
             }
         } catch {
             lastError = on
-                ? "Couldn't turn this on — add MacRazer in System Settings › General › Login Items."
-                : "Couldn't turn this off — remove MacRazer in System Settings › General › Login Items."
+                ? "Couldn't turn this on. Add MacRazer in System Settings › General › Login Items."
+                : "Couldn't turn this off. Remove MacRazer in System Settings › General › Login Items."
         }
         refresh()
     }

--- a/Sources/MacRazer/LowBatteryNotifier.swift
+++ b/Sources/MacRazer/LowBatteryNotifier.swift
@@ -135,7 +135,7 @@ final class LowBatteryNotifier: @unchecked Sendable {
 
         let content = UNMutableNotificationContent()
         content.title = "Battery Low"
-        content.body = "\(deviceName ?? "Razer mouse") is at \(percent)% — charge it soon."
+        content.body = "\(deviceName ?? "Razer mouse") is at \(percent)%. Time to charge it."
         content.sound = .default
         let request = UNNotificationRequest(
             identifier: Self.identifier(deviceKey: deviceKey), content: content, trigger: nil)

--- a/Sources/MacRazer/PermissionsView.swift
+++ b/Sources/MacRazer/PermissionsView.swift
@@ -16,7 +16,7 @@ struct PermissionsView: View {
             header
             permissionRow(
                 title: "Input Monitoring",
-                why: "Lets MacRazer talk to your mouse — battery, DPI, polling rate and lighting all need this.",
+                why: "Lets MacRazer talk to your mouse. Battery, DPI, polling rate and lighting all need it.",
                 granted: model.inputMonitoring,
                 required: true,
                 grant: { model.grantInputMonitoring() },
@@ -132,7 +132,7 @@ struct PermissionsView: View {
                     .buttonStyle(.borderedProminent).tint(.razerGreen)
                     .font(.system(size: 12, weight: .medium))
                 if model.relaunchFailed {
-                    Text("Couldn't relaunch — quit and reopen MacRazer manually.")
+                    Text("Couldn't relaunch. Quit and reopen MacRazer yourself.")
                         .font(.system(size: 10)).foregroundStyle(Color.batteryLow)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -153,7 +153,7 @@ struct PermissionsView: View {
             if controller.connected, let name = controller.deviceName {
                 Text(verbatim: "\(name) connected").font(.system(size: 11, weight: .medium))
             } else if model.inputMonitoring {
-                Text("No Razer mouse detected yet — connect the 2.4 GHz dongle or a USB-C cable (Bluetooth isn't supported).")
+                Text("No Razer mouse yet. Connect the 2.4 GHz dongle or a USB-C cable. Bluetooth won't work.")
                     .font(.system(size: 11)).foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
@@ -169,7 +169,7 @@ struct PermissionsView: View {
     /// already running has no effect until relaunch (the process caches its TCC decision).
     private var relaunchTip: some View {
         Text("Already enabled it in System Settings but it still shows “Needed”? macOS only applies "
-             + "Input Monitoring to a freshly-launched app — use Quit & Relaunch below.")
+             + "Input Monitoring to an app that has just started. Use Quit & Relaunch below.")
             .font(.system(size: 10)).foregroundStyle(.tertiary)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 4)
@@ -186,7 +186,7 @@ struct PermissionsView: View {
                     .buttonStyle(.bordered).font(.system(size: 12))
                     .help("Relaunch so macOS applies an Input Monitoring grant made while the app was running.")
                 if model.relaunchFailed {
-                    Text("Relaunch failed — quit and reopen manually.")
+                    Text("Relaunch failed. Quit and reopen MacRazer yourself.")
                         .font(.system(size: 10)).foregroundStyle(Color.batteryLow)
                 }
             }

--- a/Sources/MacRazer/PermissionsView.swift
+++ b/Sources/MacRazer/PermissionsView.swift
@@ -153,7 +153,8 @@ struct PermissionsView: View {
             if controller.connected, let name = controller.deviceName {
                 Text(verbatim: "\(name) connected").font(.system(size: 11, weight: .medium))
             } else if model.inputMonitoring {
-                Text("No Razer mouse yet. Connect the 2.4 GHz dongle or a USB-C cable. Bluetooth won't work.")
+                Text("No Razer mouse detected yet. Connect the 2.4 GHz dongle or a USB-C cable. "
+                     + "Bluetooth won't work.")
                     .font(.system(size: 11)).foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             } else {

--- a/Sources/MacRazer/PopoverView.swift
+++ b/Sources/MacRazer/PopoverView.swift
@@ -299,7 +299,7 @@ struct PopoverView: View {
                 .font(.system(size: 13, weight: .semibold))
             VStack(alignment: .leading, spacing: 2) {
                 Text("Connected via Bluetooth").font(.system(size: 12, weight: .semibold))
-                Text("\(controller.bluetoothMouseName ?? "Your Razer mouse") only reports battery, DPI and lighting over the 2.4 GHz dongle or USB-C — not Bluetooth. Switch its mode to use MacRazer.")
+                Text("\(controller.bluetoothMouseName ?? "Your Razer mouse") only reports battery, DPI and lighting over the 2.4 GHz dongle or USB-C, not over Bluetooth. Switch its mode to use MacRazer.")
                     .font(.system(size: 11)).foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -345,7 +345,7 @@ struct PopoverView: View {
                 }
                 if isAddingProfile { addProfileField }
                 if controller.profileApplyFailed {
-                    Text("Couldn't apply — the mouse isn't responding.")
+                    Text("Couldn't apply that. The mouse isn't responding.")
                         .font(.system(size: 10.5)).foregroundStyle(Color.batteryLow)
                 }
             }
@@ -433,7 +433,7 @@ struct PopoverView: View {
                     .font(.system(size: 14, weight: .semibold))
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available").font(.system(size: 12, weight: .semibold))
-                    Text("Version \(version) is out — you're on \(appVersion).")
+                    Text("Version \(version) is out. You're on \(appVersion).")
                         .font(.system(size: 11)).foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 0)
@@ -706,9 +706,9 @@ struct PopoverView: View {
         if controller.charging { return "Charging" }
         if let est = controller.timeEstimate { return est }
         if !controller.connected {
-            if controller.bluetoothMouseName != nil { return "On Bluetooth — use 2.4 GHz or USB-C" }
+            if controller.bluetoothMouseName != nil { return "On Bluetooth. Use 2.4 GHz or USB-C" }
             if needsPermission { return "Needs Input Monitoring permission" }
-            return "Disconnected — wake the mouse and refresh"
+            return "Disconnected. Wake the mouse and refresh"
         }
         if controller.batteryPercent != nil { return "Estimating time remaining…" }
         return "Reading battery…"

--- a/Sources/MacRazer/ProfilesView.swift
+++ b/Sources/MacRazer/ProfilesView.swift
@@ -27,10 +27,10 @@ struct ProfilesView: View {
                     }
                 }
                 if !controller.connected {
-                    Text("Mouse offline — profiles can be renamed or deleted, but not applied.")
+                    Text("Mouse offline. You can rename or delete profiles, but not apply them.")
                         .font(.system(size: 10.5)).foregroundStyle(.secondary)
                 } else if controller.profileApplyFailed {
-                    Text("Couldn't apply — the mouse isn't responding.")
+                    Text("Couldn't apply that. The mouse isn't responding.")
                         .font(.system(size: 10.5)).foregroundStyle(Color.batteryLow)
                 }
             }

--- a/Sources/MacRazer/RemapView.swift
+++ b/Sources/MacRazer/RemapView.swift
@@ -90,7 +90,7 @@ struct RemapView: View {
     private var pausedNote: some View {
         HStack(spacing: 8) {
             Image(systemName: "pause.circle").foregroundStyle(Color.batteryMid)
-            Text("Mouse offline — remapping is paused until it reconnects.")
+            Text("Mouse offline. Remapping is paused until it reconnects.")
                 .font(.system(size: 11)).foregroundStyle(.secondary)
             Spacer()
         }

--- a/Sources/MacRazer/SettingsView.swift
+++ b/Sources/MacRazer/SettingsView.swift
@@ -76,7 +76,7 @@ struct SettingsView: View {
             // Shown rather than hidden when unavailable: running straight from the disk image
             // is a real thing people do, and "why is this switch dead" deserves an answer.
             if !launchAtLogin.isSupported {
-                sectionNote("Move MacRazer to your Applications folder to use this — a login item "
+                sectionNote("Move MacRazer to your Applications folder to use this. A login item "
                      + "pointing into a disk image stops working the moment it's ejected.")
             } else if let error = launchAtLogin.lastError {
                 sectionNote(error, color: .batteryLow)
@@ -109,7 +109,7 @@ struct SettingsView: View {
             enabled: updateChecker.canInstallInPlace
         ) {
             if !updateChecker.canInstallInPlace {
-                sectionNote("Unavailable here — MacRazer can't replace itself from this location. "
+                sectionNote("Not available here, because MacRazer can't replace itself from this location. "
                      + "Move it to your Applications folder.")
             } else if !updateChecker.autoInstallEnabled {
                 sectionNote("Off: you'll get a dot on the menu bar icon and a card in the popover instead.")
@@ -166,7 +166,7 @@ struct SettingsView: View {
         case .downloading(let f): return "Downloading the update… \(Int(f * 100))%"
         case .installing: return "Installing the update…"
         case .restarting: return "Restarting into the new version…"
-        case .needsRestart: return "Update installed — quit and reopen MacRazer to use it."
+        case .needsRestart: return "Update installed. Quit and reopen MacRazer to use it."
         case .idle: break
         }
         if let latest = updateChecker.latestVersion {
@@ -178,7 +178,7 @@ struct SettingsView: View {
         guard let last = updateChecker.lastCheckedAt else {
             return "Not checked yet. MacRazer checks once a day."
         }
-        return "Up to date — last checked \(Self.relativeDate.localizedString(for: last, relativeTo: Date()))."
+        return "Up to date. Last checked \(Self.relativeDate.localizedString(for: last, relativeTo: Date()))."
     }
 
     // MARK: Building blocks

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -319,7 +319,7 @@ final class UpdateChecker: ObservableObject {
             NSWorkspace.shared.open(dmg)
         } catch {
             phase = .idle
-            downloadError = "Download failed — check your connection and try again."
+            downloadError = "Download failed. Check your connection and try again."
         }
     }
 

--- a/Sources/MacRazer/UpdateInstaller.swift
+++ b/Sources/MacRazer/UpdateInstaller.swift
@@ -44,7 +44,7 @@ enum UpdateInstallError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .notWritable:
-            return "MacRazer can't write to its own folder — install the update manually."
+            return "MacRazer can't write to its own folder. Install the update yourself."
         case .mountFailed:
             return "The downloaded update couldn't be opened. Try again."
         case .noAppInImage, .rejected(.wrongApp):
@@ -52,7 +52,7 @@ enum UpdateInstallError: LocalizedError, Equatable {
         case .rejected(.notNewer(let version)):
             return "The download was version \(version), which isn't newer than what you're running."
         case .signatureInvalid:
-            return "The downloaded update failed its signature check — it may be damaged."
+            return "The download failed its signature check. It may be damaged."
         case .copyFailed, .swapFailed:
             return "The update downloaded but couldn't be installed. Install it manually instead."
         }

--- a/Sources/MacRazer/UsageGraphView.swift
+++ b/Sources/MacRazer/UsageGraphView.swift
@@ -54,13 +54,13 @@ struct UsageGraphView: View {
                     } else if controller.charging {
                         // The chart keeps showing the previous charge while docked — say
                         // why it isn't moving.
-                        Text("Charging — tracking paused")
+                        Text("Charging. Tracking paused")
                             .font(.system(size: 10)).foregroundStyle(.secondary)
                     }
                 }
                 .frame(height: headerRowHeight)
                 if displaySamples.count < 4 {
-                    placeholder(controller.charging ? "Charging — usage tracking paused" : "Gathering data…")
+                    placeholder(controller.charging ? "Charging. Usage tracking paused" : "Gathering data…")
                 } else {
                     Chart {
                         // The previous charge, one flat dimmed series behind the live one

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -84,13 +84,15 @@ func openDevice() -> HIDDevice? {
 /// never makes it into the snapshot — so a page whose body is a scroll view has to be hosted
 /// in a view hierarchy and captured from there. Fixed size, because a hosting view has no
 /// window to size it.
-@MainActor func writeHostedPNG<V: View>(_ view: V, size: CGSize, to path: String) {
+@MainActor func writeHostedPNG<V: View>(_ view: V, size: CGSize? = nil, to path: String) {
     // The popover's own backdrop. `cacheDisplay` captures no window background, and the dark
     // scheme's primary text is white — without this the whole page renders white on white.
     let hosted = view.environment(\.colorScheme, .dark).background(Color(white: 0.13))
     let host = NSHostingView(rootView: AnyView(hosted))
     host.appearance = NSAppearance(named: .darkAqua)
-    host.frame = CGRect(origin: .zero, size: size)
+    // `fittingSize` when the caller has no size to give: a window-shaped view sizes to its own
+    // content, and only a scroll view needs to be told how much room it has.
+    host.frame = CGRect(origin: .zero, size: size ?? host.fittingSize)
     host.layoutSubtreeIfNeeded()
     guard let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
         print("Render failed")
@@ -223,9 +225,13 @@ case "render-about":
     let aboutPath = outputPath(args.dropFirst(), default: "about-preview.png")
     // `notes` shows the "What's new in …" row, which is otherwise only there once the app has
     // cached a release body.
-    writeViewPNG(AboutView(onDone: {}, // no window to close in a render
-                           notes: args.contains("notes") ? ReleaseNotes.parse(PreviewNotes.releaseBody) : nil),
-                 to: aboutPath)
+    //
+    // Hosted rather than `ImageRenderer`: this window is mostly buttons and links, and
+    // `ImageRenderer` draws every native control as a yellow placeholder — which is to say it
+    // could not show the one thing an About preview is for.
+    writeHostedPNG(AboutView(onDone: {}, // no window to close in a render
+                             notes: args.contains("notes") ? ReleaseNotes.parse(PreviewNotes.releaseBody) : nil),
+                   to: aboutPath)
 
 case "render-remap":
     _ = NSApplication.shared

--- a/Sources/MacRazer/main.swift
+++ b/Sources/MacRazer/main.swift
@@ -82,17 +82,26 @@ func openDevice() -> HIDDevice? {
 ///
 /// `ImageRenderer` draws a `ScrollView` as an empty box — its content is laid out lazily and
 /// never makes it into the snapshot — so a page whose body is a scroll view has to be hosted
-/// in a view hierarchy and captured from there. Fixed size, because a hosting view has no
-/// window to size it.
+/// in a view hierarchy and captured from there.
+///
+/// `size` is optional: a view that sizes itself, like a window's content, is measured with
+/// `fittingSize`. Only a scroll view has to be told how much room it has, because it will
+/// take whatever it is given.
 @MainActor func writeHostedPNG<V: View>(_ view: V, size: CGSize? = nil, to path: String) {
-    // The popover's own backdrop. `cacheDisplay` captures no window background, and the dark
-    // scheme's primary text is white — without this the whole page renders white on white.
+    // The dark backdrop every surface here stands in for. `cacheDisplay` captures no window
+    // background, and the dark scheme's primary text is white — without this the whole thing
+    // renders white on white.
     let hosted = view.environment(\.colorScheme, .dark).background(Color(white: 0.13))
     let host = NSHostingView(rootView: AnyView(hosted))
     host.appearance = NSAppearance(named: .darkAqua)
-    // `fittingSize` when the caller has no size to give: a window-shaped view sizes to its own
-    // content, and only a scroll view needs to be told how much room it has.
-    host.frame = CGRect(origin: .zero, size: size ?? host.fittingSize)
+    let frameSize = size ?? host.fittingSize
+    // A view with no intrinsic size measures as zero, and the capture below then fails with
+    // nothing to say about why. Name the cause instead.
+    guard frameSize.width > 0, frameSize.height > 0 else {
+        print("Render failed: the view has no size of its own. Pass an explicit size.")
+        return
+    }
+    host.frame = CGRect(origin: .zero, size: frameSize)
     host.layoutSubtreeIfNeeded()
     guard let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
         print("Render failed")

--- a/Tests/Scripts/release-notes-test.sh
+++ b/Tests/Scripts/release-notes-test.sh
@@ -109,8 +109,11 @@ echo "Crediting contributors"
 
 check "credits the contributor by handle" "1" "$(echo "${OUT}" | grep -c '@caseyc')"
 check "uses the PR title and number" "1" "$(echo "${OUT}" | grep -c 'Add support for the thing (#5)')"
-# A merge made by hand can have no body at all, and "@caseyc —  (#5)" reads as a mistake.
-check "no dangling dash when the merge has no PR title" "0" "$(echo "${OUT}" | grep -c -- '— *(#')"
+# A merge made by hand can have no body at all, and "@caseyc:  (#5)" reads as a mistake.
+check "no dangling colon when the merge has no PR title" "0" "$(echo "${OUT}" | grep -c -- ': *(#')"
+# The draft has to survive the check this same script applies to it. Credits used an em dash
+# until --check started rejecting them, which made the script reject its own output.
+check "the draft it writes has no em dashes" "0" "$(echo "${OUT}" | grep -c -- '—')"
 check "does not credit the repo owner in their own notes" "0" "$(echo "${OUT}" | grep -c '@theowner')"
 check "leaves out the owner's PR title too" "0" "$(echo "${OUT}" | grep -c 'Tidy something up')"
 

--- a/docs/assets/hiveship.svg
+++ b/docs/assets/hiveship.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <!-- Hiveship brand mark: a cuboctahedron viewed down its 3-fold axis. -->
+  <defs>
+    <linearGradient id="hsFront" x1="0" y1="0" x2="0.3" y2="1">
+      <stop offset="0" stop-color="#8CF3D2" />
+      <stop offset="1" stop-color="#46E6AA" />
+    </linearGradient>
+  </defs>
+  <g stroke="#0A140F" stroke-width="0.6" stroke-linejoin="round">
+    <polygon points="34,6.68 24,12.45 14,6.68" fill="#5BE8B4" />
+    <polygon points="44,24 34,29.77 34,41.32" fill="#0E6B47" />
+    <polygon points="4,24 14,29.77 14,41.32" fill="#0E6B47" />
+    <polygon points="24,12.45 34,6.68 44,24 34,29.77" fill="#27BC86" />
+    <polygon points="24,12.45 14,6.68 4,24 14,29.77" fill="#34D598" />
+    <polygon points="34,29.77 34,41.32 14,41.32 14,29.77" fill="#178A5F" />
+    <polygon points="24,12.45 34,29.77 14,29.77" fill="url(#hsFront)" />
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -324,7 +324,7 @@
   <a class="footer-hiveship" href="https://hiveship.app/">
     <img src="assets/hiveship.svg" alt="" width="24" height="24">
     <span class="footer-hiveship-text">
-      <strong>Built with Hiveship</strong>
+      <span class="footer-hiveship-title">Built with Hiveship</span>
       Issue tracking for teams handing work to coding agents.
     </span>
     <span class="footer-hiveship-go">Take a look</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -269,8 +269,8 @@
         <div>
           <p>Launch it. Grant <strong>Input Monitoring</strong> (and <strong>Accessibility</strong>
           if you use button remapping) when asked. From then on MacRazer starts at login by
-          itself, and new versions install themselves — <strong>Update &amp; Restart</strong> in
-          the popover replaces the app and relaunches it, no dragging a DMG. Both are
+          itself and new versions install themselves. <strong>Update &amp; Restart</strong> in the
+          popover replaces the app and relaunches it, so there's no DMG to drag. Both are
           switchable.</p>
         </div>
       </li>
@@ -317,6 +317,7 @@
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md">Changelog</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
+      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
       <a href="mailto:zsolt.gaspar.eng@gmail.com">Contact</a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -317,11 +317,18 @@
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/CHANGELOG.md">Changelog</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
-      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
       <a href="mailto:zsolt.gaspar.eng@gmail.com">Contact</a>
     </div>
   </div>
+  <a class="footer-hiveship" href="https://hiveship.app/">
+    <img src="assets/hiveship.svg" alt="" width="24" height="24">
+    <span class="footer-hiveship-text">
+      <strong>Built with Hiveship</strong>
+      Issue tracking for teams handing work to coding agents.
+    </span>
+    <span class="footer-hiveship-go">Take a look</span>
+  </a>
 </footer>
 
 <script>

--- a/docs/razer-mouse-battery-mac.html
+++ b/docs/razer-mouse-battery-mac.html
@@ -231,7 +231,7 @@
   <a class="footer-hiveship" href="https://hiveship.app/">
     <img src="assets/hiveship.svg" alt="" width="24" height="24">
     <span class="footer-hiveship-text">
-      <strong>Built with Hiveship</strong>
+      <span class="footer-hiveship-title">Built with Hiveship</span>
       Issue tracking for teams handing work to coding agents.
     </span>
     <span class="footer-hiveship-go">Take a look</span>

--- a/docs/razer-mouse-battery-mac.html
+++ b/docs/razer-mouse-battery-mac.html
@@ -101,7 +101,7 @@
   <section class="strip">
     <p><strong>Why macOS doesn't already show it:</strong> the dongle presents the mouse as a
     plain HID device with no battery service. The charge level only comes back if you ask for it
-    in Razer's own vendor protocol — which is what this app does.</p>
+    in Razer's own vendor protocol, which is what this app does.</p>
   </section>
 
   <section id="install" class="install">
@@ -110,7 +110,7 @@
       <li>
         <span class="step-num">1</span>
         <div>
-          <p><strong>Connect over the dongle or USB-C — not Bluetooth.</strong> Razer only exposes
+          <p><strong>Connect over the dongle or USB-C, not Bluetooth.</strong> Razer only exposes
           battery over USB. On Bluetooth no app can read it, because the mouse never reports it.</p>
         </div>
       </li>
@@ -152,8 +152,8 @@
       <article class="feature">
         <span class="feature-tag">01 · estimate</span>
         <h3>A learned time-remaining</h3>
-        <p>A flat %/hour rate is wrong for a Li-ion cell — it sits on a long voltage plateau, then
-        drops fast. MacRazer learns how long your mouse actually dwells at each percent and
+        <p>A flat %/hour rate is wrong for a Li-ion cell. It sits on a long voltage plateau and
+        then drops fast. MacRazer learns how long your mouse really spends at each percent and
         estimates from that, falling back to a linear rate until it has data.</p>
       </article>
       <article class="feature">
@@ -166,8 +166,8 @@
       <article class="feature">
         <span class="feature-tag">03 · warning</span>
         <h3>A low-battery notification</h3>
-        <p>One notification when the charge drops below 15% — re-armed by charging, so it won't
-        nag every poll. You don't have to keep opening the popover to check.</p>
+        <p>One notification when the charge drops below 15%. Charging re-arms it, so it won't
+        nag you every poll, and you don't have to keep opening the popover to check.</p>
       </article>
       <article class="feature">
         <span class="feature-tag">04 · honest</span>
@@ -182,10 +182,10 @@
     <h2>Common questions</h2>
 
     <h3>Why can't I see my Razer mouse battery in macOS System Settings?</h3>
-    <p>Because macOS only surfaces battery for devices that report it through a standard service —
-    mainly Bluetooth peripherals. A Razer mouse on its 2.4&nbsp;GHz dongle enumerates as a generic
-    USB HID device, and its charge level is only available through Razer's vendor-specific
-    protocol.</p>
+    <p>Because macOS only surfaces battery for devices that report it through a standard
+    service, which mostly means Bluetooth peripherals. A Razer mouse on its 2.4&nbsp;GHz dongle
+    enumerates as a generic USB HID device, and its charge level is only available through
+    Razer's own vendor protocol.</p>
 
     <h3>Does this work over Bluetooth?</h3>
     <p>No. This is a hardware/protocol limit, not an app limitation: Razer doesn't expose the
@@ -194,15 +194,15 @@
 
     <h3>Which mice does it read battery from?</h3>
     <p>Verified on the Razer Cobra HyperSpeed and Atheris. Cobra Pro and other models use the same
-    protocol and generally answer, but aren't hardware-verified here — see
+    protocol and generally answer, but nobody has verified them on hardware here. See
     <a href="./#mice">supported mice</a>. Wired-only mice have no battery, and the app hides that
     section rather than reporting a fake value.</p>
 
     <h3>Is the percentage exact?</h3>
-    <p>It's the mouse's own fuel-gauge reading, scaled from the raw byte the firmware returns —
-    the same source Synapse uses. Expect the usual Li-ion quirks: the reading can recover a
-    percent or two after the mouse rests, which MacRazer accounts for rather than treating as a
-    recharge.</p>
+    <p>It's the mouse's own fuel-gauge reading, scaled from the raw byte the firmware returns.
+    That's the same source Synapse uses. Expect the usual Li-ion quirks: the reading can recover
+    a percent or two after the mouse rests, which MacRazer accounts for rather than treating as
+    a recharge.</p>
 
     <p class="mice-note">Questions or a mouse that doesn't report? Open an issue on
       <a href="https://github.com/SorcRR/MacRazer/issues">GitHub</a>.</p>
@@ -225,6 +225,7 @@
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
+      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>

--- a/docs/razer-mouse-battery-mac.html
+++ b/docs/razer-mouse-battery-mac.html
@@ -225,10 +225,17 @@
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
-      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>
+  <a class="footer-hiveship" href="https://hiveship.app/">
+    <img src="assets/hiveship.svg" alt="" width="24" height="24">
+    <span class="footer-hiveship-text">
+      <strong>Built with Hiveship</strong>
+      Issue tracking for teams handing work to coding agents.
+    </span>
+    <span class="footer-hiveship-go">Take a look</span>
+  </a>
 </footer>
 
 <script>

--- a/docs/razer-synapse-alternative-mac.html
+++ b/docs/razer-synapse-alternative-mac.html
@@ -235,7 +235,7 @@
   <a class="footer-hiveship" href="https://hiveship.app/">
     <img src="assets/hiveship.svg" alt="" width="24" height="24">
     <span class="footer-hiveship-text">
-      <strong>Built with Hiveship</strong>
+      <span class="footer-hiveship-title">Built with Hiveship</span>
       Issue tracking for teams handing work to coding agents.
     </span>
     <span class="footer-hiveship-go">Take a look</span>

--- a/docs/razer-synapse-alternative-mac.html
+++ b/docs/razer-synapse-alternative-mac.html
@@ -229,10 +229,17 @@
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
-      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>
+  <a class="footer-hiveship" href="https://hiveship.app/">
+    <img src="assets/hiveship.svg" alt="" width="24" height="24">
+    <span class="footer-hiveship-text">
+      <strong>Built with Hiveship</strong>
+      Issue tracking for teams handing work to coding agents.
+    </span>
+    <span class="footer-hiveship-go">Take a look</span>
+  </a>
 </footer>
 
 <script>

--- a/docs/razer-synapse-alternative-mac.html
+++ b/docs/razer-synapse-alternative-mac.html
@@ -11,7 +11,7 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://sorcrr.github.io/MacRazer/razer-synapse-alternative-mac.html">
 <meta property="og:title" content="Razer Synapse alternative for Mac — free and open source">
-<meta property="og:description" content="Synapse for Mac doesn't cover every Razer mouse. MacRazer controls battery, DPI, RGB, polling rate and button remaps over USB HID — no account, no kernel extension.">
+<meta property="og:description" content="Synapse for Mac doesn't cover every Razer mouse. MacRazer controls battery, DPI, RGB, polling rate and button remaps over USB HID. No account, no kernel extension.">
 <meta property="og:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="Razer Synapse alternative for Mac — free and open source">
@@ -33,7 +33,7 @@
       "name": "Does Razer Synapse work on Mac?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes, Razer ships Synapse for Mac, but it runs only on Apple Silicon Macs and supports a limited list of devices. Razer publishes that supported-device list, and several mice — including the Cobra HyperSpeed and Atheris — are not on it."
+        "text": "Yes, Razer ships Synapse for Mac, but it runs only on Apple Silicon Macs and supports a limited list of devices. Razer publishes that supported-device list, and several mice are not on it, including the Cobra HyperSpeed and Atheris."
       }
     },
     {
@@ -88,7 +88,7 @@
   <div class="hero-content">
     <p class="kicker">free · open source · no account</p>
     <h1>A Razer Synapse<br>alternative for Mac.</h1>
-    <p class="hero-sub">Synapse for Mac exists now — but it's Apple Silicon only, and its
+    <p class="hero-sub">Synapse for Mac exists now, but it runs on Apple Silicon only and its
     supported-device list leaves plenty of mice out. MacRazer talks to the mouse directly over
     USB HID, so the model on Razer's "unsupported" list still gets battery, DPI, RGB, polling
     rate and button remaps.</p>
@@ -141,7 +141,7 @@
         <tr>
           <td>Macros</td>
           <td><span class="badge badge-good">Yes</span></td>
-          <td><span class="badge badge-mid">No — two side buttons remap only</span></td>
+          <td><span class="badge badge-mid">No, two side buttons remap only</span></td>
         </tr>
         <tr>
           <td>Battery history</td>
@@ -172,15 +172,15 @@
       <article class="feature">
         <span class="feature-tag">03 · lighting</span>
         <h3>RGB without Chroma</h3>
-        <p>Static colour, spectrum cycle, wave, or off, plus brightness — no Chroma runtime and
+        <p>Static colour, spectrum cycle, wave, or off, plus brightness. No Chroma runtime,
         no background service.</p>
       </article>
       <article class="feature">
         <span class="feature-tag">04 · remap</span>
         <h3>Side-button remapping</h3>
-        <p>Map the two side buttons to keys or shortcuts. Software-side, so it needs
-        Accessibility permission — and it's honest that the other buttons are handled onboard
-        and invisible to macOS.</p>
+        <p>Map the two side buttons to keys or shortcuts. It works software-side, so it needs
+        Accessibility permission. The other buttons are handled on the mouse itself and macOS
+        never sees them.</p>
       </article>
     </div>
   </section>
@@ -188,15 +188,14 @@
   <section class="mice">
     <h2>Common questions</h2>
     <h3>Does Razer Synapse work on Mac?</h3>
-    <p>Yes — Razer ships
+    <p>Yes. Razer ships
     <a href="https://www.razer.com/synapse-4-mac">Synapse for Mac</a>, on Apple Silicon only,
     with a
     <a href="https://mysupport.razer.com/app/answers/detail/a_id/14809/~/razer-synapse-for-mac-supported-and-compatible-devices">published supported-device list</a>.
     Check that list first. If your mouse is on it and you want macros, use Synapse.</p>
 
     <h3>My mouse isn't on Razer's list. Now what?</h3>
-    <p>That's the gap this app was built for — the Cobra HyperSpeed and Atheris weren't covered,
-    which is why MacRazer exists. The protocol is largely shared across models, so an
+    <p>That gap is why MacRazer exists. The Cobra HyperSpeed and Atheris weren't covered. The protocol is largely shared across models, so an
     unsupported-by-Synapse mouse usually still answers. See
     <a href="./#mice">supported mice</a> for what's actually been verified on hardware.</p>
 
@@ -206,8 +205,8 @@
     behind it.</p>
 
     <h3>Will it work over Bluetooth?</h3>
-    <p>No, and no app can. Razer only exposes the control protocol over USB — use the 2.4&nbsp;GHz
-    dongle or a USB-C cable. Over Bluetooth the mouse is just a pointer.</p>
+    <p>No, and no app can. Razer only exposes the control protocol over USB, so use the
+    2.4&nbsp;GHz dongle or a USB-C cable. Over Bluetooth the mouse is just a pointer.</p>
 
     <p class="mice-note">Still stuck? Open an issue on
       <a href="https://github.com/SorcRR/MacRazer/issues">GitHub</a>.</p>
@@ -230,6 +229,7 @@
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="releases.html">Release notes</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
+      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -89,10 +89,17 @@
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
-      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>
+  <a class="footer-hiveship" href="https://hiveship.app/">
+    <img src="assets/hiveship.svg" alt="" width="24" height="24">
+    <span class="footer-hiveship-text">
+      <strong>Built with Hiveship</strong>
+      Issue tracking for teams handing work to coding agents.
+    </span>
+    <span class="footer-hiveship-go">Take a look</span>
+  </a>
 </footer>
 
 <script>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -95,7 +95,7 @@
   <a class="footer-hiveship" href="https://hiveship.app/">
     <img src="assets/hiveship.svg" alt="" width="24" height="24">
     <span class="footer-hiveship-text">
-      <strong>Built with Hiveship</strong>
+      <span class="footer-hiveship-title">Built with Hiveship</span>
       Issue tracking for teams handing work to coding agents.
     </span>
     <span class="footer-hiveship-go">Take a look</span>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -4,18 +4,18 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Release notes | MacRazer</title>
-<meta name="description" content="Every MacRazer release and what changed in it — new mice, features and fixes for the free open-source Razer mouse app for macOS.">
+<meta name="description" content="Every MacRazer release and what changed in it: new mice, features and fixes for the free open-source Razer mouse app for macOS.">
 <meta name="author" content="SorcRR">
 <link rel="canonical" href="https://sorcrr.github.io/MacRazer/releases.html">
 
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://sorcrr.github.io/MacRazer/releases.html">
 <meta property="og:title" content="MacRazer release notes">
-<meta property="og:description" content="Every release and what changed in it — new mice, features and fixes.">
+<meta property="og:description" content="Every release and what changed in it: new mice, features and fixes.">
 <meta property="og:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MacRazer release notes">
-<meta name="twitter:description" content="Every release and what changed in it — new mice, features and fixes.">
+<meta name="twitter:description" content="Every release and what changed in it: new mice, features and fixes.">
 <meta name="twitter:image" content="https://sorcrr.github.io/MacRazer/assets/icon-1024.png">
 
 <link rel="icon" type="image/png" href="assets/favicon.png">
@@ -48,8 +48,8 @@
     <p class="kicker">changelog · every version</p>
     <h1>What changed,<br><em>and when</em>.</h1>
     <p class="hero-sub">Every MacRazer release and what was in it. These are the same notes the
-    app shows you before it installs an update — install instructions left out, since you are
-    plainly already here.</p>
+    app shows you before it installs an update. The install steps are left out, since you have
+    plainly managed that already.</p>
     <div class="hero-actions">
       <a href="https://github.com/SorcRR/MacRazer/releases/latest/download/MacRazer.dmg" class="btn btn-primary btn-large">
         Download for macOS<span id="version-tag" class="version-tag"></span>
@@ -89,6 +89,7 @@
       <a href="razer-mouse-battery-mac.html">Battery on Mac</a>
       <a href="https://github.com/SorcRR/MacRazer">GitHub</a>
       <a href="https://github.com/SorcRR/MacRazer/blob/master/LICENSE">GPL-2.0 License</a>
+      <a href="https://hiveship.app/">Built with Hiveship</a>
       <a href="https://ko-fi.com/sorcrr">Tips</a>
     </div>
   </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -624,6 +624,11 @@ tbody tr:hover { background: var(--bg-raised); }
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .footer-hiveship:hover { border-color: var(--accent-dim); background: var(--bg-raised-2); }
+.footer-hiveship:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-raised-2);
+}
 
 .footer-hiveship img { flex: none; }
 
@@ -635,7 +640,7 @@ tbody tr:hover { background: var(--bg-raised); }
   color: var(--text-faint);
   line-height: 1.45;
 }
-.footer-hiveship-text strong { color: var(--text); font-weight: 500; font-size: 13.5px; }
+.footer-hiveship-title { color: var(--text); font-weight: 500; font-size: 13.5px; }
 
 .footer-hiveship-go {
   margin-left: auto;
@@ -649,8 +654,8 @@ tbody tr:hover { background: var(--bg-raised); }
 @media (max-width: 640px) {
   .footer { padding-bottom: 32px; }
   .footer-hiveship {
-    width: calc(100% - 36px);
-    margin: 0 auto;
+    /* Not a narrower inset: `.footer-grid` keeps its 32px of side padding at every width, so
+       anything but `100% - 64px` here leaves the card overhanging the links above it. */
     align-items: flex-start;
     flex-wrap: wrap;
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -479,6 +479,10 @@ tbody tr:hover { background: var(--bg-raised); }
 .footer {
   border-top: 1px solid var(--border-soft);
   background: var(--bg-raised);
+  /* Padding, not a margin on the last child: the footer has no bottom border or padding of
+     its own, so a child's bottom margin collapses straight out of it and the background ends
+     flush against that child. */
+  padding-bottom: 48px;
 }
 
 .footer-grid {
@@ -609,7 +613,7 @@ tbody tr:hover { background: var(--bg-raised); }
      it rather than sitting 32px wider on both sides. */
   max-width: 976px;
   width: calc(100% - 64px);
-  margin: 0 auto 48px;
+  margin: 0 auto;
   padding: 14px 18px;
   display: flex;
   align-items: center;
@@ -643,9 +647,10 @@ tbody tr:hover { background: var(--bg-raised); }
 .footer-hiveship-go::after { content: " →"; }
 
 @media (max-width: 640px) {
+  .footer { padding-bottom: 32px; }
   .footer-hiveship {
     width: calc(100% - 36px);
-    margin: 0 auto 32px;
+    margin: 0 auto;
     align-items: flex-start;
     flex-wrap: wrap;
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -503,7 +503,8 @@ tbody tr:hover { background: var(--bg-raised); }
 
 .footer-links {
   display: flex;
-  gap: 26px;
+  flex-wrap: wrap;
+  gap: 12px 26px;
   font-size: 13px;
   color: var(--text-dim);
 }
@@ -600,4 +601,55 @@ tbody tr:hover { background: var(--bg-raised); }
 @media (max-width: 640px) {
   .releases { padding: 48px 18px 64px; }
   .release-version { font-size: 22px; }
+}
+
+/* ---------- built with Hiveship ---------- */
+.footer-hiveship {
+  /* 1040 minus the footer grid's 32px of side padding, so this lines up with the links above
+     it rather than sitting 32px wider on both sides. */
+  max-width: 976px;
+  width: calc(100% - 64px);
+  margin: 0 auto 48px;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.footer-hiveship:hover { border-color: var(--accent-dim); background: var(--bg-raised-2); }
+
+.footer-hiveship img { flex: none; }
+
+.footer-hiveship-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12.5px;
+  color: var(--text-faint);
+  line-height: 1.45;
+}
+.footer-hiveship-text strong { color: var(--text); font-weight: 500; font-size: 13.5px; }
+
+.footer-hiveship-go {
+  margin-left: auto;
+  flex: none;
+  font-size: 12.5px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.footer-hiveship-go::after { content: " →"; }
+
+@media (max-width: 640px) {
+  .footer-hiveship {
+    width: calc(100% - 36px);
+    margin: 0 auto 32px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  /* Wrapped onto its own row, so it starts at the box's padding edge like everything else
+     in it. The desktop rule pushes it to the far right, which leaves it floating here. */
+  .footer-hiveship-go { margin-left: 0; }
 }


### PR DESCRIPTION
A "For developers" section in the About window, plus a rewrite of the window's copy.

> **FOR DEVELOPERS**
> MacRazer was built with Hiveship. It's an issue tracker for planning work, tracking bugs, and handing issues to coding agents as well as the people on your team.
> `↗ Go to Hiveship`

Saying it was used to build this gives a reader a reason to look, rather than a product description sitting in an About box for no stated reason.

In About rather than the popover: the popover is what people open daily to read a battery percentage, and nothing permanent there stays subtle past the third time you see it. About already carries a Ko-fi button, so a link there surprises nobody.

## The copy rewrite

The whole window read like a machine wrote it. Em dashes in almost every paragraph, clauses stacked three deep, a semicolon joining two sentences that wanted to be two sentences. Same facts throughout, including the trademark disclaimer and the licence wording, which are there for a reason and only got shorter.

| before | after |
|---|---|
| The device protocol, command bytes, the report structure, CRC, the Cobra command set, was ported from OpenRazer's Linux driver. The hard reverse-engineering is theirs. | Everything this app says to your mouse was ported from OpenRazer's Linux driver: the command bytes, the report structure, the CRC, the Cobra command set. They did the hard reverse engineering. |
| GPL-2.0-or-later, GPL because it derives from OpenRazer, which is GPL. | GPL-2.0-or-later. It has to be GPL, because it builds on OpenRazer. |
| ...used here only to describe compatibility. The app's mouse mark is its own; it does not display Razer's logo. | They are used here only to say which mice this works with. The mouse icon is the app's own drawing, not Razer's logo. |

No em dashes left in any string the user sees.

## A preview fix that came with it

`render-about` went through `ImageRenderer`, which draws every native control as a placeholder, and that window is almost entirely buttons and links. The preview could not show a new button at all, which is how the first version of this went visually unchecked. It uses the hosted `NSHostingView` path now, sized from the view's own `fittingSize`, and the whole window renders properly for the first time.

## Verification

- 141 tests pass, changelog guard passes
- `render-about notes` inspected: every section reads correctly and the buttons render with their real labels
