### PR TITLE
Fetch the release notes when the cache predates the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Fixed
+- **"What's new" was empty for everyone upgrading to 0.4.0.** The notes are read from a cache
+ the previous version fills, and 0.3.0 had no such cache: it predates the feature. So the
+ release that introduced "What's new" showed its "Updated to 0.4.0" card with nothing to
+ open, and the daily check throttle meant it stayed that way for up to a day, because the
+ old version had checked minutes earlier. A version change with no notes for it now beats the
+ throttle, which is the one case where the cache is known to be stale rather than merely old.
+ It fills itself on that check, so this does not turn a version change into an unthrottled
+ app.
+
 ## [0.4.0] — 2026-09-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ expect rough edges until 1.0.
 
 ## [Unreleased]
 
+### Changed
+- **`UpdateChecker` takes the defaults store it reads.** Every decision in it is a pure
+ function with tests, and both bugs this feature shipped were in the wiring between those
+ functions and the keys: an announcement held only in memory, then notes read from a cache
+ written by a version that had no such key. Neither could be stated as a test while the store
+ was `UserDefaults.standard`. Six tests now cover that wiring, including both bugs, and each
+ was checked by reverting the fix to confirm the test fails without it.
+
 ### Fixed
 - **"What's new" was empty for everyone upgrading to 0.4.0.** The notes are read from a cache
  the previous version fills, and 0.3.0 had no such cache: it predates the feature. So the
@@ -14,7 +22,13 @@ expect rough edges until 1.0.
  old version had checked minutes earlier. A version change with no notes for it now beats the
  throttle, which is the one case where the cache is known to be stale rather than merely old.
  It fills itself on that check, so this does not turn a version change into an unthrottled
- app.
+ app, and the attempt is recorded so a release published with no body is not refetched at
+ every launch.
+
+- **Links in release notes are links again.** The parser reduced `[text](url)` to its text
+ before storing it, so a body that linked anywhere reached the popover as bare words with no
+ way to follow them. Items keep their markdown now and the page renders it, which also means
+ bold inside a sentence shows as bold rather than being flattened.
 
 ## [0.4.0] — 2026-09-11
 

--- a/Sources/MacRazer/RazerDevices.swift
+++ b/Sources/MacRazer/RazerDevices.swift
@@ -56,6 +56,10 @@ struct RazerDeviceInfo {
     /// Basilisk V3 X HyperSpeed — whose only lit zone is the scroll wheel — answers on
     /// SCROLL_LED and returns FAILURE (0x03) for LOGO, ZERO and BACKLIGHT alike
     /// (hardware-verified via the `brightness` probe).
+    /// The default is LOGO_LED, verified by the `brightness` probe on the Cobra family and on
+    /// the Viper Ultimate (#6). It is an assumption on every other lit model here. A wrong id
+    /// does not error, the slider just stops working, so a model gaining lighting support
+    /// should be swept with `swift run MacRazer brightness` rather than inheriting this.
     var brightnessLed: UInt8 = Razer.logoLed
     let connection: RazerConnection
     let silhouette: RazerMouseSilhouette

--- a/Sources/MacRazer/ReleaseNotes.swift
+++ b/Sources/MacRazer/ReleaseNotes.swift
@@ -11,11 +11,21 @@ import Foundation
 /// rather than being dropped.
 struct ReleaseNotes: Equatable {
     /// One bullet, split so the popover can set the first line apart from the rest.
+    ///
+    /// Both halves are kept as markdown and stripped on demand. They used to be stored
+    /// stripped, which threw the URL away: `[the docs](https://…)` reached the view as "the
+    /// docs" with no way to follow it, and a release body that linked anywhere produced dead
+    /// words on screen.
     struct Item: Equatable {
-        /// The gist. Empty when the bullet has no natural lead, in which case `detail` carries
-        /// the whole thing rather than the item being silently thinned to nothing.
-        let headline: String
-        let detail: String
+        /// The gist, as written. Empty when the bullet has no natural lead, in which case
+        /// `detail` carries the whole thing rather than the item being silently thinned to
+        /// nothing.
+        let headlineSource: String
+        let detailSource: String
+
+        /// Plain text, for measuring, comparing and anywhere markdown would show through.
+        var headline: String { ReleaseNotes.strip(headlineSource) }
+        var detail: String { ReleaseNotes.strip(detailSource) }
     }
 
     /// A heading, e.g. "Added" / "Fixed", with the bullets under it. The title is empty for
@@ -133,7 +143,7 @@ struct ReleaseNotes: Equatable {
             let headline = String(text[text.index(text.startIndex, offsetBy: 2)..<close.lowerBound])
             let rest = String(text[close.upperBound...])
             if headline.count <= maxHeadline {
-                return Item(headline: strip(headline), detail: strip(trimLead(rest)))
+                return Item(headlineSource: headline, detailSource: trimLead(rest))
             }
         }
 
@@ -141,10 +151,10 @@ struct ReleaseNotes: Equatable {
             let headline = String(text[..<end])
             if headline.count <= maxHeadline {
                 let rest = String(text[end...])
-                return Item(headline: strip(headline), detail: strip(trimLead(rest)))
+                return Item(headlineSource: headline, detailSource: trimLead(rest))
             }
         }
-        return Item(headline: "", detail: strip(text))
+        return Item(headlineSource: "", detailSource: text)
     }
 
     /// Index just past the first ". " — not `.` alone, which would cut "0.3.1" and "e.g." in

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -65,16 +65,32 @@ final class UpdateChecker: ObservableObject {
     /// because some *other* property happened to change around each check — first `isChecking`,
     /// then a write-only counter added to make that deliberate. Storing it removes the
     /// question: the value the view reads is the value that publishes.
-    @Published private(set) var lastCheckedAt: Date? =
-        UserDefaults.standard.object(forKey: UpdateChecker.lastCheckKey) as? Date
+    @Published private(set) var lastCheckedAt: Date?
 
     /// Install updates without asking. **Off by default**: installing and relaunching behind
     /// someone's back is a much bigger thing to do to them than putting a dot on the menu bar,
     /// and this app isn't Apple-notarised — opting in should be deliberate. The caller decides
     /// *when* an automatic install is acceptable (`AppDelegate` won't start one with the
     /// popover open); this flag only says whether it may.
-    @Published var autoInstallEnabled: Bool = UserDefaults.standard.bool(forKey: UpdateChecker.autoInstallKey) {
-        didSet { UserDefaults.standard.set(autoInstallEnabled, forKey: Self.autoInstallKey) }
+    @Published var autoInstallEnabled: Bool = false {
+        didSet { defaults.set(autoInstallEnabled, forKey: Self.autoInstallKey) }
+    }
+
+    /// Where the state above is kept between launches.
+    ///
+    /// Injectable, and not because anything else stores it elsewhere. Every *decision* in this
+    /// class is a pure function with tests, and both bugs this feature shipped were in the
+    /// wiring between those functions and these keys: an announcement held only in memory, and
+    /// then a cache written by a version that had no such key. Neither could be written as a
+    /// test while the store was `UserDefaults.standard`.
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        lastCheckedAt = defaults.object(forKey: Self.lastCheckKey) as? Date
+        // Assigned after `defaults` exists, and directly to the backing store, so the `didSet`
+        // above does not write the value straight back during initialisation.
+        _autoInstallEnabled = Published(initialValue: defaults.bool(forKey: Self.autoInstallKey))
     }
 
     private let releaseAPIURL = ProjectLinks.latestReleaseAPI
@@ -89,6 +105,7 @@ final class UpdateChecker: ObservableObject {
     private static let lastRunVersionKey = "lastRunVersion"
     private static let dismissedAnnouncementKey = "dismissedUpdateAnnouncement"
     private static let pendingAnnouncementKey = "pendingUpdateAnnouncement"
+    private static let notesCheckedForKey = "notesCheckedForVersion"
 
     private struct GitHubRelease: Decodable {
         let tag_name: String
@@ -111,7 +128,7 @@ final class UpdateChecker: ObservableObject {
         if Self.isCheckDue(lastChecked: lastCheckedAt,
                            now: Date(),
                            interval: checkInterval,
-                           notesMissingForNewVersion: justUpdatedTo != nil && installedNotes == nil) {
+                           notesMissingForNewVersion: notesWorthFetching) {
             await checkForUpdatesNow()
             return
         }
@@ -119,6 +136,22 @@ final class UpdateChecker: ObservableObject {
         // Otherwise a relaunch forgets a known update for up to a day.
         restoreLastFound()
     }
+
+    /// A fresh version with no notes, and no check made for it yet.
+    ///
+    /// The last clause is what stops this repeating. Without it, a release published with no
+    /// body leaves `installedNotes` nil however many checks run, so every launch would skip
+    /// the throttle and go to the network again for as long as the announcement stood.
+    private var notesWorthFetching: Bool {
+        justUpdatedTo != nil
+            && installedNotes == nil
+            && defaults.string(forKey: Self.notesCheckedForKey) != currentVersion
+    }
+
+    #if DEBUG
+    /// The condition above, for the test that states when it must stop firing.
+    var notesWorthFetchingForTesting: Bool { notesWorthFetching }
+    #endif
 
     /// Whether to go to the network now.
     ///
@@ -164,16 +197,16 @@ final class UpdateChecker: ObservableObject {
             // Clearing it up front spent the user's decision even when the request then
             // failed, and `restoreLastFound()` would resurrect the very version they had
             // dismissed, having learned nothing.
-            if userRequested { UserDefaults.standard.removeObject(forKey: Self.dismissedKey) }
+            if userRequested { defaults.removeObject(forKey: Self.dismissedKey) }
             // Only a *successful* check counts against the daily throttle: a failed one
             // (offline right after wake is common) should retry on the next opportunity,
             // not silence update notices for a day.
             let checkedAt = Date()
-            UserDefaults.standard.set(checkedAt, forKey: Self.lastCheckKey)
-            UserDefaults.standard.set(remote, forKey: Self.lastFoundKey)
-            UserDefaults.standard.set(release.body ?? "", forKey: Self.lastFoundNotesKey)
+            defaults.set(checkedAt, forKey: Self.lastCheckKey)
+            defaults.set(remote, forKey: Self.lastFoundKey)
+            defaults.set(release.body ?? "", forKey: Self.lastFoundNotesKey)
             lastCheckedAt = checkedAt
-            let dismissed = UserDefaults.standard.string(forKey: Self.dismissedKey)
+            let dismissed = defaults.string(forKey: Self.dismissedKey)
             if Self.isNewer(remote, than: currentVersion), remote != dismissed {
                 latestVersion = remote
                 latestNotes = Self.notes(from: release.body)
@@ -183,7 +216,10 @@ final class UpdateChecker: ObservableObject {
             }
             // The same response answers "what am I running?" — someone who installed by hand
             // gets their notes from the first check after, without waiting for a next release.
-            installedNotes = Self.installedNotes(current: currentVersion)
+            installedNotes = Self.installedNotes(current: currentVersion, defaults: defaults)
+            // Asked and answered, whatever the answer was. A release with no body has no notes
+            // to find, and retrying that on every launch would be a request that cannot help.
+            defaults.set(currentVersion, forKey: Self.notesCheckedForKey)
         } catch {
             // Silent: a failed background check shouldn't surface as an error — only an
             // explicit download attempt should show one. But do surface what the last
@@ -196,16 +232,16 @@ final class UpdateChecker: ObservableObject {
     /// not-dismissed are re-evaluated, so updating or dismissing in the meantime clears it).
     private func restoreLastFound() {
         guard latestVersion == nil,
-              let found = UserDefaults.standard.string(forKey: Self.lastFoundKey) else { return }
-        let dismissed = UserDefaults.standard.string(forKey: Self.dismissedKey)
+              let found = defaults.string(forKey: Self.lastFoundKey) else { return }
+        let dismissed = defaults.string(forKey: Self.dismissedKey)
         if Self.isNewer(found, than: currentVersion), found != dismissed {
             latestVersion = found
-            latestNotes = Self.notes(from: UserDefaults.standard.string(forKey: Self.lastFoundNotesKey))
+            latestNotes = Self.notes(from: defaults.string(forKey: Self.lastFoundNotesKey))
         }
     }
 
     func dismiss(_ version: String) {
-        UserDefaults.standard.set(version, forKey: Self.dismissedKey)
+        defaults.set(version, forKey: Self.dismissedKey)
         latestVersion = nil
         latestNotes = nil
     }
@@ -217,7 +253,6 @@ final class UpdateChecker: ObservableObject {
     /// that is killed, crashes, or is replaced under itself never gets a clean shutdown, and
     /// the one thing worse than a missed announcement is the same one every launch.
     func loadInstalledVersionState() {
-        let defaults = UserDefaults.standard
         let current = currentVersion
         let pending = UpdateAnnouncement.pending(
             lastRun: defaults.string(forKey: Self.lastRunVersionKey),
@@ -234,7 +269,7 @@ final class UpdateChecker: ObservableObject {
             defaults.removeObject(forKey: Self.pendingAnnouncementKey)
         }
         defaults.set(current, forKey: Self.lastRunVersionKey)
-        installedNotes = Self.installedNotes(current: current)
+        installedNotes = Self.installedNotes(current: current, defaults: defaults)
     }
 
     /// Evidence that some version of MacRazer has run on this machine before.
@@ -252,7 +287,6 @@ final class UpdateChecker: ObservableObject {
     }
 
     func dismissAnnouncement() {
-        let defaults = UserDefaults.standard
         if let version = justUpdatedTo {
             defaults.set(version, forKey: Self.dismissedAnnouncementKey)
         }
@@ -262,8 +296,8 @@ final class UpdateChecker: ObservableObject {
 
     /// The same notes, for a caller with no `UpdateChecker` to hand — the About window, which
     /// observes nothing.
-    static func notesForRunningVersion() -> ReleaseNotes? {
-        installedNotes(current: AppInfo.comparableVersion)
+    static func notesForRunningVersion(defaults: UserDefaults = .standard) -> ReleaseNotes? {
+        installedNotes(current: AppInfo.comparableVersion, defaults: defaults)
     }
 
     /// The cached notes, but only when they are demonstrably about the version running.
@@ -272,11 +306,10 @@ final class UpdateChecker: ObservableObject {
     /// or not it was newer — so this answers for someone who installed the DMG by hand too,
     /// from the first check after they did. A mismatch means the cache is about some other
     /// release and showing it would be worse than showing nothing.
-    private static func installedNotes(current: String) -> ReleaseNotes? {
-        let defaults = UserDefaults.standard
-        return notes(for: current,
+    private static func installedNotes(current: String, defaults: UserDefaults) -> ReleaseNotes? {
+        notes(for: current,
                      cachedVersion: defaults.string(forKey: lastFoundKey),
-                     cachedBody: defaults.string(forKey: lastFoundNotesKey))
+              cachedBody: defaults.string(forKey: lastFoundNotesKey))
     }
 
     /// The rule, kept apart from the defaults it reads so it can be stated in a test: notes

--- a/Sources/MacRazer/UpdateChecker.swift
+++ b/Sources/MacRazer/UpdateChecker.swift
@@ -108,13 +108,36 @@ final class UpdateChecker: ObservableObject {
     /// Checks at most once per `checkInterval`, regardless of how often this is called — safe to
     /// call on every launch and from a repeating timer.
     func checkForUpdatesIfDue() async {
-        if let last = lastCheckedAt, Date().timeIntervalSince(last) < checkInterval {
-            // Within the throttle window, surface what the last successful check already
-            // found — otherwise a relaunch forgets a known update for up to a day.
-            restoreLastFound()
+        if Self.isCheckDue(lastChecked: lastCheckedAt,
+                           now: Date(),
+                           interval: checkInterval,
+                           notesMissingForNewVersion: justUpdatedTo != nil && installedNotes == nil) {
+            await checkForUpdatesNow()
             return
         }
-        await checkForUpdatesNow()
+        // Within the throttle window, surface what the last successful check already found.
+        // Otherwise a relaunch forgets a known update for up to a day.
+        restoreLastFound()
+    }
+
+    /// Whether to go to the network now.
+    ///
+    /// The throttle exists so the app asks once a day however often it launches. It has one
+    /// exception, and 0.4.0 is what found it: the version just changed and there are no notes
+    /// for what is now running, which means the cache was written by the version that is no
+    /// longer here. Every 0.3.0 install hit this, because 0.3.0 had no notes cache at all, so
+    /// the release that introduced "What's new" showed the card with nothing to open. Waiting
+    /// out a day for text that is already published is the wrong trade.
+    ///
+    /// Self-limiting: the check it forces fills the cache, so the next call takes the
+    /// ordinary path.
+    static func isCheckDue(lastChecked: Date?,
+                           now: Date,
+                           interval: TimeInterval,
+                           notesMissingForNewVersion: Bool) -> Bool {
+        if notesMissingForNewVersion { return true }
+        guard let lastChecked else { return true }
+        return now.timeIntervalSince(lastChecked) >= interval
     }
 
     /// Bypasses the throttle — used by `checkForUpdatesIfDue()` once due, and by the menu's

--- a/Sources/MacRazer/WhatsNewPage.swift
+++ b/Sources/MacRazer/WhatsNewPage.swift
@@ -88,16 +88,28 @@ struct WhatsNewPage: View {
         }
     }
 
+    /// Markdown as an `AttributedString`, so a link in a release note is a link.
+    ///
+    /// Falls back to the plain text when the markdown will not parse. A release body is prose
+    /// somebody typed, and a page that renders nothing because one bullet had a stray bracket
+    /// would be a worse failure than one that renders it flat.
+    private static func rendered(_ markdown: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: markdown,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(ReleaseNotes.strip(markdown))
+    }
+
     @ViewBuilder
     private func itemRow(_ item: ReleaseNotes.Item) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             if !item.headline.isEmpty {
-                Text(item.headline)
+                Text(Self.rendered(item.headlineSource))
                     .font(.system(size: 11.5, weight: .semibold))
                     .fixedSize(horizontal: false, vertical: true)
             }
             if !item.detail.isEmpty {
-                Text(item.detail)
+                Text(Self.rendered(item.detailSource))
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Tests/MacRazerTests/ReleaseNotesTests.swift
+++ b/Tests/MacRazerTests/ReleaseNotesTests.swift
@@ -109,6 +109,16 @@ final class ReleaseNotesTests: XCTestCase {
         XCTAssertEqual(ReleaseNotes.strip("see [the docs](https://example.com) here"), "see the docs here")
     }
 
+    func testAnItemKeepsItsMarkdownSoLinksSurvive() {
+        // Stored stripped, a link reached the view as bare words with no URL: "see the docs"
+        // leading nowhere. The view needs the original to make it a link.
+        let i = ReleaseNotes.item(from: "**A page.** See [the docs](https://example.com) for more.")
+        XCTAssertEqual(i.headline, "A page.")
+        XCTAssertEqual(i.detail, "See the docs for more.", "plain text still reads as plain text")
+        XCTAssertTrue(i.detailSource.contains("(https://example.com)"),
+                      "and the URL is still there for the view to render")
+    }
+
     func testAStrayBracketDoesNotSwallowTheTextAfterIt() {
         // Pairing the first `[` with the first later `](` destroyed everything between them.
         // Release bodies now carry changelog prose verbatim, and that prose has brackets in it.

--- a/Tests/MacRazerTests/UpdateAnnouncementTests.swift
+++ b/Tests/MacRazerTests/UpdateAnnouncementTests.swift
@@ -121,3 +121,44 @@ final class InstalledNotesTests: XCTestCase {
         XCTAssertNil(UpdateChecker.notes(for: "0.3.1", cachedVersion: "0.3.1", cachedBody: ""))
     }
 }
+
+/// The daily throttle, and the one case that has to escape it.
+@MainActor
+final class CheckDueTests: XCTestCase {
+    private let day: TimeInterval = 24 * 60 * 60
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    func testNeverCheckedIsDue() {
+        XCTAssertTrue(UpdateChecker.isCheckDue(lastChecked: nil, now: now, interval: day,
+                                               notesMissingForNewVersion: false))
+    }
+
+    func testWithinTheWindowIsNot() {
+        XCTAssertFalse(UpdateChecker.isCheckDue(lastChecked: now.addingTimeInterval(-3600),
+                                                now: now, interval: day,
+                                                notesMissingForNewVersion: false))
+    }
+
+    func testPastTheWindowIs() {
+        XCTAssertTrue(UpdateChecker.isCheckDue(lastChecked: now.addingTimeInterval(-day - 1),
+                                               now: now, interval: day,
+                                               notesMissingForNewVersion: false))
+    }
+
+    func testAFreshVersionWithNoNotesBeatsTheThrottle() {
+        // What 0.4.0 shipped with. The old version checked minutes before the update, so the
+        // throttle was wide open, and 0.3.0 never cached a body at all — the release that
+        // introduced "What's new" showed its card with nothing behind it, for a day.
+        XCTAssertTrue(UpdateChecker.isCheckDue(lastChecked: now.addingTimeInterval(-60),
+                                               now: now, interval: day,
+                                               notesMissingForNewVersion: true))
+    }
+
+    func testItDoesNotBecomeACheckOnEveryLaunch() {
+        // Once the forced check stores the body there are notes, and the throttle applies
+        // again. Nothing here should make a version change mean an unthrottled app.
+        XCTAssertFalse(UpdateChecker.isCheckDue(lastChecked: now.addingTimeInterval(-60),
+                                                now: now, interval: day,
+                                                notesMissingForNewVersion: false))
+    }
+}

--- a/Tests/MacRazerTests/UpdateCheckerStateTests.swift
+++ b/Tests/MacRazerTests/UpdateCheckerStateTests.swift
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Part of MacRazer, a control app for Razer mice on macOS. See LICENSE and NOTICE.md.
+
+import XCTest
+@testable import MacRazer
+
+/// The wiring between `UpdateChecker`'s decisions and the defaults they read.
+///
+/// Every decision here is a pure function tested elsewhere. This covers the part that was not
+/// testable until the store could be injected, which is exactly where both of this feature's
+/// shipped bugs were: an announcement kept only in memory, and then notes read from a cache
+/// written by a version that had no such key.
+@MainActor
+final class UpdateCheckerStateTests: XCTestCase {
+    // Made per test rather than in setUp: `setUp`/`tearDown` are nonisolated, and this class
+    // has to be `@MainActor` to touch `UpdateChecker` at all.
+    private func makeDefaults() -> (UserDefaults, String) {
+        let suite = "MacRazerTests-\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    private func withDefaults(_ body: (UserDefaults) throws -> Void) rethrows {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        try body(defaults)
+    }
+
+    private var running: String { AppInfo.comparableVersion }
+
+    func testAFirstRunAnnouncesNothingAndRecordsTheVersion() {
+        withDefaults { defaults in
+            let checker = UpdateChecker(defaults: defaults)
+            checker.loadInstalledVersionState()
+            XCTAssertNil(checker.justUpdatedTo)
+            XCTAssertEqual(defaults.string(forKey: "lastRunVersion"), running)
+        }
+    }
+
+    func testAVersionChangeAnnouncesOnce() {
+        withDefaults { defaults in
+            defaults.set("0.0.1", forKey: "lastRunVersion")
+            defaults.set(true, forKey: "launchAtLoginDefaultApplied")
+
+            let first = UpdateChecker(defaults: defaults)
+            first.loadInstalledVersionState()
+            XCTAssertEqual(first.justUpdatedTo, running)
+
+            // Still owed on the next launch, because the card waits for the popover to be opened.
+            let second = UpdateChecker(defaults: defaults)
+            second.loadInstalledVersionState()
+            XCTAssertEqual(second.justUpdatedTo, running)
+
+            second.dismissAnnouncement()
+            let third = UpdateChecker(defaults: defaults)
+            third.loadInstalledVersionState()
+            XCTAssertNil(third.justUpdatedTo, "a dismissal has to survive a relaunch")
+        }
+    }
+
+    func testTheAnnouncementSurvivesARelaunchBeforeItIsSeen() {
+        withDefaults { defaults in
+            // The first bug: `justUpdatedTo` was derived once and held in memory while the version
+            // was written to defaults immediately, so a reboot before opening the popover lost it.
+            defaults.set("0.0.1", forKey: "lastRunVersion")
+            defaults.set(true, forKey: "launchAtLoginDefaultApplied")
+            UpdateChecker(defaults: defaults).loadInstalledVersionState()
+
+            XCTAssertEqual(defaults.string(forKey: "pendingUpdateAnnouncement"), running,
+                           "the announcement has to be written down, not just held")
+        }
+    }
+
+    func testNotesAreShownOnlyForTheVersionRunning() {
+        withDefaults { defaults in
+            defaults.set(running, forKey: "lastFoundUpdateVersion")
+            defaults.set("A summary.\n\n### Added\n- **A thing.** It happened.", forKey: "lastFoundUpdateNotes")
+
+            let checker = UpdateChecker(defaults: defaults)
+            checker.loadInstalledVersionState()
+            XCTAssertNotNil(checker.installedNotes)
+
+            defaults.set("99.0.0", forKey: "lastFoundUpdateVersion")
+            let other = UpdateChecker(defaults: defaults)
+            other.loadInstalledVersionState()
+            XCTAssertNil(other.installedNotes, "a cache about another release must not answer")
+        }
+    }
+
+    func testAnUpgradeFromAVersionWithNoNotesCacheGoesStraightToTheNetwork() {
+        withDefaults { defaults in
+            // The second bug, reported from a real 0.3.0 install. 0.3.0 never wrote a notes cache,
+            // so the row had nothing to open, and the old version's own check minutes earlier left
+            // the throttle wide open for a day.
+            defaults.set("0.0.1", forKey: "lastRunVersion")
+            defaults.set(true, forKey: "launchAtLoginDefaultApplied")
+            defaults.set(Date(), forKey: "lastUpdateCheckDate") // checked a moment ago
+
+            let checker = UpdateChecker(defaults: defaults)
+            checker.loadInstalledVersionState()
+
+            XCTAssertNotNil(checker.justUpdatedTo)
+            XCTAssertNil(checker.installedNotes)
+            XCTAssertTrue(UpdateChecker.isCheckDue(lastChecked: checker.lastCheckedAt,
+                                                   now: Date(),
+                                                   interval: 24 * 60 * 60,
+                                                   notesMissingForNewVersion: checker.justUpdatedTo != nil
+                                                       && checker.installedNotes == nil),
+                          "a fresh version with no notes must not wait out the throttle")
+        }
+    }
+
+    func testABodylessReleaseIsNotRefetchedOnEveryLaunch() {
+        // The exception exists for a cache written by an older version. A release with no body
+        // leaves the notes nil no matter how often it is fetched, so without a record of the
+        // attempt it would bypass the throttle at every launch for a request that cannot help.
+        withDefaults { defaults in
+            defaults.set("0.0.1", forKey: "lastRunVersion")
+            defaults.set(true, forKey: "launchAtLoginDefaultApplied")
+            defaults.set(Date(), forKey: "lastUpdateCheckDate")
+            defaults.set(AppInfo.comparableVersion, forKey: "notesCheckedForVersion")
+
+            let checker = UpdateChecker(defaults: defaults)
+            checker.loadInstalledVersionState()
+            XCTAssertNotNil(checker.justUpdatedTo)
+            XCTAssertNil(checker.installedNotes)
+            XCTAssertFalse(checker.notesWorthFetchingForTesting,
+                           "already asked for this version, so the throttle applies again")
+        }
+    }
+
+    func testAutoInstallDefaultsOffAndPersists() {
+        withDefaults { defaults in
+            XCTAssertFalse(UpdateChecker(defaults: defaults).autoInstallEnabled)
+            let checker = UpdateChecker(defaults: defaults)
+            checker.autoInstallEnabled = true
+            XCTAssertTrue(UpdateChecker(defaults: defaults).autoInstallEnabled,
+                          "the setting has to outlive the object that set it")
+        }
+    }
+}


### PR DESCRIPTION
Reported from a real install: after updating 0.3.0 → 0.4.0 the popover shows **Updated to 0.4.0** with no **What's new** row under it.

## Why

The row is gated on notes for the running version, and those come from a cache the *previous* version fills. `lastFoundUpdateNotes` was added in 0.4.0, so 0.3.0 never wrote one:

```
$ git show v0.3.0:Sources/MacRazer/UpdateChecker.swift | grep -c lastFoundUpdateNotes
0
```

Confirmed against the real preferences after the upgrade: `lastFoundUpdateVersion = "0.4.0"` and `lastRunVersion = "0.4.0"` are both there, `lastFoundUpdateNotes` is absent entirely. So `installedNotes` is nil and the row hides itself, exactly as designed for "no notes", except there are notes and they are published.

The 24 hour throttle then made it stick. The old version had checked minutes before installing, so the new one was well inside the window, skipped the network call, and would not have filled the cache for another 23 hours.

So the release that introduced "What's new" is the release where it could not work. Same shape as the `hasRunBefore` fix already in 0.4.0, which handled the card; this is the notes behind it.

## The fix

`isCheckDue` gains one exception: the running version changed and there are no notes for it. That is the one case where the cache is known to be *wrong* rather than merely old, because whatever wrote it was a version that is no longer here.

It is self-limiting. The forced check stores the body, so the next call sees notes and takes the ordinary throttled path. A version change does not turn into an unthrottled app, and there is a test saying so.

## Workaround on 0.4.0

Right-click the menu bar icon → **Check for Updates…**. That already bypasses the throttle, fills the cache and makes the row appear.

## Verification

- 146 tests, 5 new ones covering the throttle and its exception
- changelog guard passes


---

## Follow-up: a review over the whole 0.4.0 release

The bug above was found by using the app, not by reviewing it, so I reviewed `v0.3.0..HEAD` as a whole looking for the same class of thing. Eight findings; four fixed here, four left with reasons.

### The pattern behind both bugs

Every *decision* in `UpdateChecker` was already a pure function with tests. What had no test was the wiring between those functions and the defaults keys, and that is where both shipped defects were: the announcement held only in memory, then notes read from a cache written by a version that had no such key.

`UpdateChecker` takes its store now, defaulting to `.standard`. Six tests cover the wiring, including both bugs. **Each was mutation-checked** by reverting the fix it covers and confirming the suite fails:

```
mutation 1 (in-memory announcement):   2 assertion failures
mutation 2 (no throttle exception):    2 assertion failures
```

### Links in release notes were dead text

The parser reduced `[text](url)` to its text before storing it, so a body linking anywhere reached the popover as bare words. The 0.4.0 notes link to the releases page; on the site it is clickable, in the app it was not. Items keep their markdown now and the page renders it through `AttributedString`, with a plain-text fallback if it will not parse. Mid-sentence bold renders as bold too, where it was flattened before.

### Two smaller ones

The throttle exception now records that it asked, so a release published with no body is not refetched at every launch. And `brightnessLed` documents which models its LOGO default is verified on, the Cobra family and the Viper Ultimate, and that it is an assumption everywhere else.

### Left alone, with reasons

- **No passive signal for the "Updated to" card.** The dot is reserved for pending updates, so with auto-install on the announcement waits in a popover that may not be opened for days. That is a product call about how much the app may nag, not a defect.
- **`hasRunBefore` misses an offline user running from a DMG.** The proxies are the only evidence available, and from 0.4.0 onward `lastRunVersion` is the real record, so the gap closes itself after this release.
- **A bullet naming two things headlines only the first.** The fix is to write two bullets, not to teach the parser to count subjects.
- **`--check` is advice, not a gate.** The script cannot run it on the draft it just wrote, because that draft always contains the placeholder by design.

### One I chased and dropped

Viper Ultimate is `fullySupported: true` with the default brightness LED, which looked like exactly the assumption that failed silently on the Basilisk V3 X. The PR body mentions only button detection, but the probe output is in #6's review thread and LOGO answers with a real 33% reading. The default is correct there.

### Verification

- 154 tests, 7 new
- release-notes, release-script and changelog guards pass
- `render-ui whatsnew` inspected against the real body
